### PR TITLE
避免 MeshMaterial 复用缓存程序时 drawContext 为空`

### DIFF
--- a/libs/scene/src/material/meshmaterial.ts
+++ b/libs/scene/src/material/meshmaterial.ts
@@ -229,6 +229,21 @@ export class MeshMaterial extends Material implements Clonable<MeshMaterial> {
     this.objectColor = other.objectColor;
   }
   /**
+   * Capture the active draw context for both cached and freshly-built program paths.
+   *
+   * The shader-building hooks access `this.drawContext`, but uniform application may also
+   * consult it on subsequent frames when the GPU program is reused from cache. Updating it
+   * here keeps material mixins in sync even when `createProgram()` is skipped.
+   *
+   * @param ctx - Current draw context.
+   * @returns Whether material preparation succeeded.
+   */
+  apply(ctx: DrawContext) {
+    this._ctx = ctx;
+    this._materialPass = -1;
+    return super.apply(ctx);
+  }
+  /**
    * Mark uniform-only changes so uniforms are re-uploaded on next apply, without
    * rebuilding shader programs.
    */
@@ -901,6 +916,9 @@ export class MeshMaterial extends Material implements Clonable<MeshMaterial> {
    */
   needFragmentColor(ctx?: DrawContext) {
     const drawContext = ctx ?? this.drawContext;
+    if (!drawContext?.renderPass) {
+      return this._alphaCutoff > 0 || this.alphaToCoverage;
+    }
     return (
       drawContext.renderPass!.type === RENDER_PASS_TYPE_LIGHT || this._alphaCutoff > 0 || this.alphaToCoverage
     );


### PR DESCRIPTION
变更范围
- `libs/scene/src/material/meshmaterial.ts`

## 变更目标
修复桌面端打开项目时，`MeshMaterial` 复用缓存程序导致 `drawContext` 为空，从而触发 PBR / SSS / transmission 分支异常的问题。

## 主要改动
- 让 `MeshMaterial` 在每次 `apply()` 时刷新 `drawContext`
- 避免缓存程序复用时沿用失效的渲染上下文

## 测试方式
- 在桌面端打开包含相关材质配置的项目
- 确认项目可以正常打开，不再因 `drawContext` 为空崩溃