### PR TITLE
优化脚本属性面板交互与显示

### DIFF
--- a/utility/editor/src/components/grid.ts
+++ b/utility/editor/src/components/grid.ts
@@ -1163,7 +1163,8 @@ export class PropertyEditor extends Observable<{
         : ImGui.GetContentRegionAvail().x;
     let changed = false;
     if (isSceneNodeRef || isAssetRef) {
-      this.renderClippedStringField('##value_display', val[0], fieldWidth, false);
+      const displayText = isSceneNodeRef ? this.resolveSceneNodeRefLabel(object, val[0]) : val[0];
+      this.renderClippedStringField('##value_display', displayText, fieldWidth, false);
     } else {
       const clicked = this.renderClippedStringField('##value_display', val[0], fieldWidth, canInlineEdit);
       if (clicked && canInlineEdit) {
@@ -1470,6 +1471,39 @@ export class PropertyEditor extends Observable<{
     }
     eventBus.dispatchEvent('reveal_asset', ProjectService.VFS.normalizePath(path));
   }
+  private resolveSceneNodeRefHost(object: any): Nullable<SceneNode> {
+    if (object instanceof SceneNode) {
+      return object;
+    }
+    if (object?.host instanceof SceneNode) {
+      return object.host;
+    }
+    if (object?.scriptHost instanceof SceneNode) {
+      return object.scriptHost;
+    }
+    if (this.object instanceof SceneNode) {
+      return this.object;
+    }
+    return null;
+  }
+  private resolveSceneNodeRefLabel(object: any, value: string) {
+    const id = String(value ?? '').trim();
+    if (!id) {
+      return '';
+    }
+    const host = this.resolveSceneNodeRefHost(object);
+    const scope = host
+      ? ((typeof (host as any)?.getPrefabNode === 'function' && (host as any).getPrefabNode()) ||
+        host.scene?.rootNode ||
+        host)
+      : null;
+    const node = scope?.findNodeById?.(id);
+    if (node instanceof SceneNode) {
+      const name = String(node.name ?? '').trim();
+      return name || node.persistentId || id;
+    }
+    return `[Missing] ${id}`;
+  }
   private revealAssetFromProperty(object: any, prop: PropertyAccessor<any>) {
     if (!prop.options?.mimeTypes?.length) {
       return;
@@ -1642,9 +1676,10 @@ export class PropertyEditor extends Observable<{
                   )
                 : customTextInput('##value', val, '', readonly ? CustomInputTextFlags.ReadOnly : 0);
             } else {
+              const displayText = isSceneNodeRef ? this.resolveSceneNodeRefLabel(object, val[0]) : val[0];
               const clicked = this.renderClippedStringField(
                 '##value_display',
-                val[0],
+                displayText,
                 fieldWidth,
                 canInlineEdit
               );

--- a/utility/editor/src/components/grid.ts
+++ b/utility/editor/src/components/grid.ts
@@ -313,6 +313,14 @@ class PropertyGroup {
   }
 }
 
+function isScriptArrayElementObject(value: unknown): value is {
+  constructor: { __scriptArrayElement?: boolean };
+  propertyName?: unknown;
+  index?: unknown;
+} {
+  return !!value && typeof value === 'object' && !!(value as any).constructor?.__scriptArrayElement;
+}
+
 export class PropertyEditor extends Observable<{
   request_edit_aabb: [aabb: AABB];
   end_edit_aabb: [aabb: AABB];
@@ -425,6 +433,19 @@ export class PropertyEditor extends Observable<{
   private getGroupLabel(group: PropertyGroup) {
     if (group === this._rootGroup) {
       return 'Root';
+    }
+    const currentObject = group.value.object?.[0];
+    if (isScriptArrayElementObject(currentObject) && group.prop?.type === 'object_array') {
+      const baseLabel =
+        group.prop.options?.label ??
+        (typeof currentObject.propertyName === 'string' && currentObject.propertyName
+          ? currentObject.propertyName
+          : group.name);
+      const index =
+        typeof currentObject.index === 'number' && Number.isFinite(currentObject.index)
+          ? currentObject.index
+          : group.index;
+      return `${baseLabel}[${index}]`;
     }
     return group.prop?.options?.label ?? group.name;
   }
@@ -700,7 +721,11 @@ export class PropertyEditor extends Observable<{
       return;
     }
     const opened = this._groupOpenStates.get(group.statePath);
-    group.opened = opened ?? this.getNearestObjectGroup(group) === this._rootGroup;
+    group.opened =
+      opened ??
+      (isScriptArrayElementObject(group.value.object?.[0])
+        ? true
+        : this.getNearestObjectGroup(group) === this._rootGroup);
   }
   private getPropertyHeight(property: Property<any>) {
     return this.getTableRowHeight(property.value?.options?.multiline ? 100 : undefined);
@@ -821,6 +846,7 @@ export class PropertyEditor extends Observable<{
       (group.prop.type === 'object' || group.prop.type === 'object_array') &&
       group.objectTypes
     ) {
+      const isScriptArrayElement = isScriptArrayElementObject(group.value.object?.[0]);
       const editable =
         (group.value.object?.[0] instanceof AABB && group.prop.options?.edit === 'aabb') ||
         (group.value.object?.[0] instanceof PropertyTrack && group.prop.options?.edit === 'proptrack') ||
@@ -830,7 +856,7 @@ export class PropertyEditor extends Observable<{
       const settable =
         !group.prop.readonly &&
         !!group.prop.set &&
-        (group.prop.type === 'object' || group.index < group.count);
+        (group.prop.type === 'object' || (!isScriptArrayElement && group.index < group.count));
       const addable = group.prop.type === 'object_array' && !!group.prop.add;
       const deletable = group.prop.type === 'object_array' && group.prop.delete && group.index < group.count;
       const showTypeSelector = group.objectTypes.length > 1;
@@ -894,12 +920,19 @@ export class PropertyEditor extends Observable<{
             ) {
               this.inspectGroup(group);
               const ctor = group.objectTypes[group.selected[0]]?.ctor;
-              const newObj = ctor
-                ? group.prop.create
-                  ? group.prop.create.call(group.object, ctor, group.index)
-                  : new ctor()
-                : null;
-              (group.prop.add<'object'>).call(group.object, { object: [newObj] }, group.index);
+              const insertIndex = group.index + 1;
+              const newObj = isScriptArrayElement
+                ? null
+                : ctor
+                  ? group.prop.create
+                    ? group.prop.create.call(group.object, ctor, insertIndex)
+                    : new ctor()
+                  : null;
+              (group.prop.add<'object'>).call(
+                group.object,
+                { object: newObj ? [newObj] : [] },
+                insertIndex
+              );
               this.dispatchEvent('object_property_changed', group.object, group.prop);
               this.refresh();
             }
@@ -995,12 +1028,19 @@ export class PropertyEditor extends Observable<{
             if (ImGui.Button(`${FontGlyph.glyphs['plus']}##add`, new ImGui.ImVec2(buttonSize, 0))) {
               this.inspectGroup(group);
               const ctor = group.objectTypes[0]?.ctor;
-              const newObj = ctor
-                ? group.prop.create
-                  ? group.prop.create.call(group.object, ctor, group.index)
-                  : new ctor()
-                : null;
-              (group.prop.add<'object'>).call(group.object, { object: [newObj] }, group.index);
+              const insertIndex = group.index + 1;
+              const newObj = isScriptArrayElement
+                ? null
+                : ctor
+                  ? group.prop.create
+                    ? group.prop.create.call(group.object, ctor, insertIndex)
+                    : new ctor()
+                  : null;
+              (group.prop.add<'object'>).call(
+                group.object,
+                { object: newObj ? [newObj] : [] },
+                insertIndex
+              );
               this.dispatchEvent('object_property_changed', group.object, group.prop);
               this.refresh();
             }

--- a/utility/editor/src/components/grid.ts
+++ b/utility/editor/src/components/grid.ts
@@ -545,6 +545,9 @@ export class PropertyEditor extends Observable<{
     }
     for (const extraProps of results) {
       for (const prop of extraProps ?? []) {
+        if (prop.isHidden?.call(object, -1, object)) {
+          continue;
+        }
         targetGroup.addProperty(object, prop);
       }
     }

--- a/utility/editor/src/components/scriptpanel.ts
+++ b/utility/editor/src/components/scriptpanel.ts
@@ -206,6 +206,9 @@ export class ScriptPanel {
           attachmentIndex: this._selectedScriptIndex
         }
       : null;
+    if (this._scriptConfigEditorHost?.scriptPath) {
+      clearScriptPropertyAccessorCache(this._scriptConfigEditorHost.scriptPath);
+    }
     this._scriptConfigGrid.object = this._scriptConfigEditorHost;
     this._scriptConfigGrid.setExtraPropertiesProvider(
       'script-config',

--- a/utility/editor/src/helpers/scriptprops.ts
+++ b/utility/editor/src/helpers/scriptprops.ts
@@ -189,15 +189,22 @@ function getScriptConfigObject(host: ScriptHost, scriptPath?: string, attachment
 
 function getPropertyOptions(
   info: RuntimeScriptValueDeclaration | RuntimeScriptPropertyInfo,
-  scriptGroup?: string
+  scriptGroup?: string,
+  useDefaultScriptGroup = true
 ): PropertyAccessorOptions {
   const group = scriptGroup
     ? info.group
       ? `Script/${scriptGroup}/${info.group}`
-      : `Script/${scriptGroup}`
+      : useDefaultScriptGroup
+        ? `Script/${scriptGroup}`
+        : undefined
     : info.group
-      ? `Script/${info.group}`
-      : 'Script';
+      ? useDefaultScriptGroup
+        ? `Script/${info.group}`
+        : info.group
+      : useDefaultScriptGroup
+        ? 'Script'
+        : undefined;
   if (info.type === 'asset') {
     return {
       label: info.label,
@@ -462,6 +469,7 @@ function writeScalarFromInput(type: RuntimeScriptValueType, value: any) {
 }
 
 class ScriptArrayElement {
+  static readonly __scriptArrayElement = true;
   host: ScriptHost;
   scriptPath: string;
   attachmentIndex: number;
@@ -525,7 +533,7 @@ function getArrayElementSerializationClass(
           {
             name: 'Value',
             type: getScalarPropertyType(scalarElement.type),
-            options: getPropertyOptions(scalarElement),
+            options: getPropertyOptions(scalarElement, undefined, false),
             isHidden() {
               return !!scalarElement.hidden;
             },
@@ -547,7 +555,7 @@ function getArrayElementSerializationClass(
           ({
             name: field.name,
             type: getScalarPropertyType(field.type),
-            options: getPropertyOptions(field),
+            options: getPropertyOptions(field, undefined, false),
             isHidden() {
               return !!field.hidden;
             },

--- a/utility/editor/src/helpers/scriptprops.ts
+++ b/utility/editor/src/helpers/scriptprops.ts
@@ -803,7 +803,16 @@ export async function getScriptPropertyAccessors(host: unknown): Promise<Propert
 
 export function clearScriptPropertyAccessorCache(path?: Nullable<string>) {
   if (path) {
-    propertyCache.delete(path);
+    const normalized = String(path).trim();
+    for (const key of [...propertyCache.keys()]) {
+      if (
+        key === normalized ||
+        key.startsWith(`${normalized}::`) ||
+        key.split('|').some((part) => part === normalized)
+      ) {
+        propertyCache.delete(key);
+      }
+    }
   } else {
     propertyCache.clear();
   }


### PR DESCRIPTION
## 变更范围
- `utility/editor/src/components/grid.ts`
- `utility/editor/src/components/scriptpanel.ts`
- `utility/editor/src/helpers/scriptprops.ts`

## 变更目标
提升脚本属性面板的可读性和交互体验，减少错误显示和缓存失效问题。

## 主要改动
- 节点引用字段优先显示节点名称，不再直接显示 UUID
- `extraProperties` 链路补齐 `isHidden` 过滤
- 切换到脚本配置面板时按脚本路径清理属性缓存
- 修正脚本属性缓存失效逻辑
- 优化对象数组属性面板交互

## 测试方式
- 打开带脚本组件的对象
- 检查节点引用字段显示是否正确
- 检查隐藏属性是否仍被错误显示
- 修改脚本后重新切回属性面板，确认属性定义能够刷新
- 验证对象数组属性的新增/插入交互