### PR TITLE
完善开发态启动与插件 Link 基础能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ utility/editor/release/
 
 # VSCodeCounter
 .VSCodeCounter
+/AGENTS.md

--- a/utility/editor/README.md
+++ b/utility/editor/README.md
@@ -46,6 +46,18 @@ Build and launch the Electron desktop app for development:
 npm run electron:dev --prefix utility/editor
 ```
 
+Install a Windows desktop shortcut for the development runtime:
+
+```sh
+npm run electron:dev:install-shortcut --prefix utility/editor
+```
+
+Launch the development runtime through the shortcut-compatible launcher:
+
+```sh
+npm run electron:dev:launch --prefix utility/editor
+```
+
 Launch the Electron app from an existing build:
 
 ```sh
@@ -65,6 +77,22 @@ The Electron build is an additive desktop runtime for the browser editor.
 - Browser builds continue to use the existing VFS abstraction and browser storage.
 - Desktop builds expose a constrained preload bridge instead of direct Node.js access in renderer code.
 - Editor metadata, system plugins, and local projects are stored under Electron `app.getPath('userData')/editor-storage`.
+
+## Windows Dev Shortcut
+
+The Windows development shortcut launches `utility/editor/scripts/launch-electron-dev.ps1`, which starts the same dev runtime as `npm run electron:dev`.
+
+- The first launch starts the Vite dev server and the Electron shell in the background.
+- Launching the shortcut again reuses the existing dev runtime when it is already running.
+- If the editor window was closed accidentally while the dev runtime is still alive, launching the shortcut again opens a new Electron window against the same dev server.
+- Runtime state and launcher logs are stored under `%LOCALAPPDATA%\Zephyr3DEditor\dev-runtime`. If that location is not writable, the launcher falls back to `utility/editor/.dev-runtime`.
+
+Development shortcut update behavior:
+
+- Changes under `utility/editor/src` update through the Vite dev server, usually with HMR or an automatic page reload.
+- Changes under `utility/editor/electron`, `utility/editor/mcp`, and `utility/editor/package.json` trigger an Electron process restart.
+- Changes under `libs/base`, `libs/device`, `libs/scene`, `libs/loaders`, `libs/backend-webgl`, and `libs/backend-webgpu` are wired to source in dev mode and should refresh into the running desktop editor.
+- Packaged desktop builds created by `npm run electron:dist` do not track source changes automatically. Rebuild or repackage them after code changes.
 
 ## MCP Integration
 

--- a/utility/editor/electron/README.md
+++ b/utility/editor/electron/README.md
@@ -16,6 +16,14 @@ npm run build --prefix utility/editor
 npm run electron:start --prefix utility/editor
 ```
 
+Windows development shortcut:
+
+```sh
+npm run electron:dev:install-shortcut --prefix utility/editor
+```
+
+This creates a desktop shortcut named `Zephyr3D Editor (Dev).lnk` that launches the development runtime without opening a terminal window.
+
 Packaging:
 
 ```sh

--- a/utility/editor/package.json
+++ b/utility/editor/package.json
@@ -41,6 +41,8 @@
     "deploy": "npm run build && shx rm -rf ../../apps/homepage/editor && shx cp -R dist ../../apps/homepage/editor",
     "electron:start": "electron .",
     "electron:dev": "node ./scripts/electron-dev.cjs",
+    "electron:dev:launch": "node ./scripts/launch-electron-dev.cjs",
+    "electron:dev:install-shortcut": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/install-desktop-shortcut.ps1",
     "electron:prepare": "node ./scripts/prepare-electron-app.cjs",
     "electron:pack": "rush build -t editor && npm run electron:prepare && electron-builder --projectDir .electron-app --config ../electron-builder.json --dir",
     "electron:dist": "rush build -t editor && npm run electron:prepare && electron-builder --projectDir .electron-app --config ../electron-builder.json",

--- a/utility/editor/scripts/dev-runtime-state.cjs
+++ b/utility/editor/scripts/dev-runtime-state.cjs
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function normalizeEditorRoot(editorRoot) {
+  return path.resolve(editorRoot);
+}
+
+function toStateKey(editorRoot) {
+  const normalizedRoot = normalizeEditorRoot(editorRoot);
+  return normalizedRoot.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'default';
+}
+
+function canUseDirectory(dirPath) {
+  try {
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.accessSync(dirPath, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getRuntimeBaseDir(editorRoot) {
+  const explicitDir =
+    typeof process.env.ZEPHYR_EDITOR_DEV_RUNTIME_DIR === 'string' ? process.env.ZEPHYR_EDITOR_DEV_RUNTIME_DIR.trim() : '';
+  const candidates = [];
+  if (explicitDir) {
+    candidates.push(path.resolve(explicitDir));
+  }
+  if (process.env.LOCALAPPDATA) {
+    candidates.push(path.join(process.env.LOCALAPPDATA, 'Zephyr3DEditor', 'dev-runtime'));
+  }
+  candidates.push(path.join(normalizeEditorRoot(editorRoot), '.dev-runtime'));
+  candidates.push(path.join(os.tmpdir(), 'Zephyr3DEditor', 'dev-runtime'));
+
+  for (const candidate of candidates) {
+    if (candidate && canUseDirectory(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error('Could not find a writable directory for the Zephyr3D Editor dev runtime state.');
+}
+
+function getRuntimeStateDir(editorRoot) {
+  return path.join(getRuntimeBaseDir(editorRoot), toStateKey(editorRoot));
+}
+
+function ensureRuntimeStateDir(editorRoot) {
+  const stateDir = getRuntimeStateDir(editorRoot);
+  fs.mkdirSync(stateDir, { recursive: true });
+  return stateDir;
+}
+
+function getRuntimeStateFilePath(editorRoot) {
+  return path.join(getRuntimeStateDir(editorRoot), 'state.json');
+}
+
+function getRuntimeLogFilePath(editorRoot) {
+  return path.join(getRuntimeStateDir(editorRoot), 'launcher.log');
+}
+
+function readRuntimeState(editorRoot) {
+  try {
+    return JSON.parse(fs.readFileSync(getRuntimeStateFilePath(editorRoot), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeRuntimeState(editorRoot, state) {
+  ensureRuntimeStateDir(editorRoot);
+  const filePath = getRuntimeStateFilePath(editorRoot);
+  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function clearRuntimeState(editorRoot) {
+  try {
+    fs.rmSync(getRuntimeStateFilePath(editorRoot), { force: true });
+  } catch {
+    // Ignore stale state cleanup errors.
+  }
+}
+
+function clearRuntimeStateIfOwned(editorRoot, runnerPid) {
+  const state = readRuntimeState(editorRoot);
+  if (state?.runnerPid === runnerPid) {
+    clearRuntimeState(editorRoot);
+  }
+}
+
+module.exports = {
+  clearRuntimeState,
+  clearRuntimeStateIfOwned,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  getRuntimeStateDir,
+  getRuntimeStateFilePath,
+  readRuntimeState,
+  writeRuntimeState
+};

--- a/utility/editor/scripts/electron-dev.cjs
+++ b/utility/editor/scripts/electron-dev.cjs
@@ -3,6 +3,13 @@ const http = require('http');
 const https = require('https');
 const path = require('path');
 const { spawn } = require('child_process');
+const {
+  clearRuntimeStateIfOwned,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  readRuntimeState,
+  writeRuntimeState
+} = require('./dev-runtime-state.cjs');
 
 const projectRoot = path.resolve(__dirname, '..');
 const explicitDevUrl = process.env.ZEPHYR_EDITOR_ELECTRON_URL || '';
@@ -45,9 +52,16 @@ let restartTimer = null;
 let restartPromise = null;
 let pendingRestartReason = '';
 const fileWatchers = [];
+const runtimeLogPath = getRuntimeLogFilePath(projectRoot);
+const runtimeStateDir = ensureRuntimeStateDir(projectRoot);
 
 function log(message) {
   process.stdout.write(`[electron:dev] ${message}\n`);
+  try {
+    fs.appendFileSync(runtimeLogPath, `[${new Date().toISOString()}] [electron:dev] ${message}\n`, 'utf8');
+  } catch {
+    // Ignore diagnostic log write failures.
+  }
 }
 
 function stripAnsi(text) {
@@ -155,7 +169,26 @@ async function cleanup(exitCode = 0) {
   }
   closeWatchers();
   await Promise.all([terminateChild(electronProcess), terminateChild(serverProcess)]);
+  clearRuntimeStateIfOwned(projectRoot, process.pid);
   process.exit(exitCode);
+}
+
+function persistRuntimeState() {
+  const current = readRuntimeState(projectRoot);
+  if (current?.runnerPid && current.runnerPid !== process.pid) {
+    return;
+  }
+  writeRuntimeState(projectRoot, {
+    version: 1,
+    status: shuttingDown ? 'stopping' : 'running',
+    editorRoot: projectRoot,
+    runnerPid: process.pid,
+    serverPid: serverProcess?.pid ?? null,
+    electronPid: electronProcess?.pid ?? null,
+    devUrl,
+    logPath: runtimeLogPath,
+    updatedAt: new Date().toISOString()
+  });
 }
 
 function waitForDevServer(rawUrl, timeoutMs) {
@@ -233,6 +266,7 @@ async function startDevServer() {
 
     pipeOutput(serverProcess.stdout, process.stdout, handleOutputLine);
     pipeOutput(serverProcess.stderr, process.stderr, handleOutputLine);
+    persistRuntimeState();
 
     serverProcess.on('error', finishReject);
     serverProcess.on('exit', (code) => {
@@ -255,6 +289,7 @@ async function startDevServer() {
   } else {
     log(`Vite dev server ready at ${devUrl}`);
   }
+  persistRuntimeState();
 }
 
 function startElectron() {
@@ -271,6 +306,7 @@ function startElectron() {
   });
 
   electronProcess = child;
+  persistRuntimeState();
 
   child.on('error', (error) => {
     console.error(error);
@@ -281,6 +317,7 @@ function startElectron() {
     if (electronProcess === child) {
       electronProcess = null;
     }
+    persistRuntimeState();
     if (!shuttingDown) {
       if (restartingElectron) {
         return;
@@ -309,6 +346,7 @@ async function performElectronRestart(reason) {
   if (!shuttingDown) {
     startElectron();
   }
+  persistRuntimeState();
 }
 
 function queueElectronRestart(reason) {
@@ -398,15 +436,18 @@ function startWatchers() {
 }
 
 async function main() {
+  persistRuntimeState();
   if (!explicitDevUrl) {
     await startDevServer();
   } else {
     log(`Using external dev server ${devUrl}`);
+    persistRuntimeState();
   }
 
   await waitForDevServer(devUrl, 120000);
   startElectron();
   startWatchers();
+  log(`Runtime state is tracked under ${runtimeStateDir}`);
 }
 
 process.on('SIGINT', () => {

--- a/utility/editor/scripts/install-desktop-shortcut.ps1
+++ b/utility/editor/scripts/install-desktop-shortcut.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param(
+  [string]$ShortcutPath = (Join-Path ([Environment]::GetFolderPath('Desktop')) 'Zephyr3D Editor (Dev).lnk')
+)
+
+$editorRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$launcherScript = (Resolve-Path (Join-Path $PSScriptRoot 'launch-electron-dev.ps1')).Path
+$iconPath = (Resolve-Path (Join-Path $editorRoot 'electron\icon.ico')).Path
+$powershellExe = (Get-Command powershell.exe -ErrorAction Stop).Source
+
+$shortcutDirectory = Split-Path -Parent $ShortcutPath
+if ($shortcutDirectory) {
+  New-Item -ItemType Directory -Force -Path $shortcutDirectory | Out-Null
+}
+
+$shell = New-Object -ComObject WScript.Shell
+$shortcut = $shell.CreateShortcut($ShortcutPath)
+$shortcut.TargetPath = $powershellExe
+$shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcherScript`""
+$shortcut.WorkingDirectory = $editorRoot
+$shortcut.IconLocation = $iconPath
+$shortcut.Description = 'Launches the Zephyr3D Editor Electron dev runtime for this workspace.'
+$shortcut.Save()
+
+Write-Output "Created shortcut: $ShortcutPath"

--- a/utility/editor/scripts/launch-electron-dev.cjs
+++ b/utility/editor/scripts/launch-electron-dev.cjs
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const {
+  clearRuntimeState,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  readRuntimeState,
+  writeRuntimeState
+} = require('./dev-runtime-state.cjs');
+
+const editorRoot = path.resolve(__dirname, '..');
+const devRunnerScript = path.join(__dirname, 'electron-dev.cjs');
+
+function isPidRunning(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveElectronBinary() {
+  try {
+    return require('electron');
+  } catch {
+    throw new Error('Electron dependency is not installed. Run npm install or rush update first.');
+  }
+}
+
+function appendLauncherLog(logPath, message) {
+  fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`, 'utf8');
+}
+
+function launchElectronInstance(existingState) {
+  const electronBinary = resolveElectronBinary();
+  const env = {
+    ...process.env
+  };
+  if (existingState?.devUrl) {
+    env.ZEPHYR_EDITOR_ELECTRON_URL = existingState.devUrl;
+  }
+  const child = spawn(electronBinary, ['.'], {
+    cwd: editorRoot,
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env
+  });
+  child.unref();
+}
+
+function startDetachedDevRunner() {
+  ensureRuntimeStateDir(editorRoot);
+  const logPath = getRuntimeLogFilePath(editorRoot);
+  const logFd = fs.openSync(logPath, 'a');
+  appendLauncherLog(logPath, 'Starting detached Electron dev runner');
+  const child = spawn(process.execPath, [devRunnerScript], {
+    cwd: editorRoot,
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    windowsHide: true,
+    env: {
+      ...process.env
+    }
+  });
+  child.unref();
+  fs.closeSync(logFd);
+  writeRuntimeState(editorRoot, {
+    version: 1,
+    status: 'launching',
+    editorRoot,
+    runnerPid: child.pid,
+    serverPid: null,
+    electronPid: null,
+    devUrl: '',
+    logPath,
+    updatedAt: new Date().toISOString()
+  });
+}
+
+function main() {
+  const existingState = readRuntimeState(editorRoot);
+  if (existingState?.runnerPid && isPidRunning(existingState.runnerPid)) {
+    if ((existingState.electronPid && isPidRunning(existingState.electronPid)) || existingState.devUrl) {
+      launchElectronInstance(existingState);
+    }
+    return;
+  }
+  clearRuntimeState(editorRoot);
+  startDetachedDevRunner();
+}
+
+try {
+  main();
+} catch (error) {
+  const stateDir = ensureRuntimeStateDir(editorRoot);
+  const logPath = getRuntimeLogFilePath(editorRoot);
+  appendLauncherLog(logPath, `Launcher failed: ${error?.stack || error}`);
+  process.stderr.write(`Failed to launch Zephyr3D Editor dev runtime. See ${path.join(stateDir, path.basename(logPath))}\n`);
+  process.stderr.write(`${error?.message || error}\n`);
+  process.exit(1);
+}

--- a/utility/editor/scripts/launch-electron-dev.ps1
+++ b/utility/editor/scripts/launch-electron-dev.ps1
@@ -1,0 +1,31 @@
+Add-Type -AssemblyName PresentationFramework
+
+function Show-LauncherError([string]$Message) {
+  [System.Windows.MessageBox]::Show(
+    $Message,
+    'Zephyr3D Editor (Dev)',
+    [System.Windows.MessageBoxButton]::OK,
+    [System.Windows.MessageBoxImage]::Error
+  ) | Out-Null
+}
+
+$editorRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$launcherPath = (Resolve-Path (Join-Path $PSScriptRoot 'launch-electron-dev.cjs')).Path
+$nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+
+if (-not $nodeCommand) {
+  Show-LauncherError 'Node.js was not found in PATH. Install Node.js first, then rerun the shortcut.'
+  exit 1
+}
+
+try {
+  $process = Start-Process -FilePath $nodeCommand.Source -ArgumentList @($launcherPath) -WorkingDirectory $editorRoot -WindowStyle Hidden -PassThru
+  $process.WaitForExit()
+  if ($process.ExitCode -ne 0) {
+    Show-LauncherError 'The Zephyr3D Editor dev launcher failed. Check the launcher log under %LOCALAPPDATA%\Zephyr3DEditor\dev-runtime.'
+    exit $process.ExitCode
+  }
+} catch {
+  Show-LauncherError ("Failed to launch the Zephyr3D Editor dev runtime.`n`n{0}" -f $_.Exception.Message)
+  exit 1
+}

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -909,6 +909,16 @@ export class Editor {
     return SystemPluginService.listPlugins();
   }
 
+  async refreshSystemPlugins() {
+    const refreshedLinkedPlugins = await SystemPluginService.refreshLinkedPlugins();
+    for (const plugin of refreshedLinkedPlugins) {
+      if (plugin.enabled) {
+        await this.tryLoadSystemPlugin(plugin.id, true);
+      }
+    }
+    return SystemPluginService.listPlugins();
+  }
+
   async installSystemPluginFromFile(file: File) {
     const plugin = await SystemPluginService.installPluginFromFile(file);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
@@ -919,6 +929,20 @@ export class Editor {
     const plugin = await SystemPluginService.installPluginFromDirectory(files);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
     return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
+  }
+
+  async linkSystemPlugin(directory: string, entryFileName?: string) {
+    const plugin = await SystemPluginService.linkPlugin({
+      directory,
+      entryFileName,
+      enabled: true
+    });
+    const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
+    return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
+  }
+
+  async unlinkSystemPlugin(id: string) {
+    await this.removeSystemPlugin(id);
   }
 
   async installSystemPluginFiles(input: {

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -287,6 +287,17 @@ export class Editor {
     }
     await ProjectService.VFS.writeFile(path, content, { encoding: 'utf8', create: true });
   }
+  async deleteProjectFile(path: string) {
+    if (!this._currentProject) {
+      throw new Error('No project is currently open');
+    }
+    if (ProjectService.VFS.readOnly) {
+      throw new Error('Current project is read-only');
+    }
+    if (await ProjectService.VFS.exists(path)) {
+      await ProjectService.VFS.deleteFile(path);
+    }
+  }
   async openProjectCodeFile(path: string, language?: string) {
     if (!this._currentProject) {
       throw new Error('No project is currently open');
@@ -641,6 +652,7 @@ export class Editor {
         const project = await ProjectService.openProject(uuid);
         const settings = await ProjectService.getCurrentProjectSettings();
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         let scene = settings.startupScene ?? project.lastEditScene ?? '';
         if (!scene) {
           const sceneFiles = await ProjectService.VFS.glob('/**/*.zscn', {
@@ -699,6 +711,7 @@ export class Editor {
         }
         const project = await ProjectService.openProject(uuid);
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         this._moduleManager.activate('Scene', '');
         return this._currentProject.uuid;
       } catch (err) {
@@ -726,6 +739,7 @@ export class Editor {
       const project = await ProjectService.openRemoteProject(url, new RemoteProjectDirectoryReader(fileList));
       this._currentProject = project;
       this._isRemoteProject = true;
+      this._plugins.dispatchEvent('projectOpened', project);
       this.loadDepTypes();
       const settings = await ProjectService.getCurrentProjectSettings();
       await this._moduleManager.activate(
@@ -749,6 +763,7 @@ export class Editor {
         const project = await ProjectService.openProject(id);
         const settings = await ProjectService.getCurrentProjectSettings();
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         this.loadDepTypes();
         this._moduleManager.activate('Scene', settings.startupScene ?? project.lastEditScene ?? '');
         for (const dep of Object.keys(settings.dependencies ?? {})) {

--- a/utility/editor/src/core/pluginapi.ts
+++ b/utility/editor/src/core/pluginapi.ts
@@ -156,6 +156,7 @@ export type EditorEditToolFactoryContext = {
 };
 
 export type EditorEventMap = {
+  projectOpened: [project: EditorProjectInfo];
   sceneOpening: [path: string];
   sceneOpened: [scene: unknown, path: string];
   sceneCreated: [scene: unknown, path: string];

--- a/utility/editor/src/core/services/storage.ts
+++ b/utility/editor/src/core/services/storage.ts
@@ -18,6 +18,13 @@ export function createProjectVFS(uuid: string): VFS {
   return getDesktopAPI() ? createElectronProjectFS(uuid) : new IndexedDBFS(uuid, STORE_NAME);
 }
 
+export function createLinkedDirectoryVFS(directory: string): VFS {
+  if (!getDesktopAPI()) {
+    throw new Error('Linked plugins are only supported in the desktop editor');
+  }
+  return createElectronProjectFS(directory);
+}
+
 export async function deleteProjectVFS(uuid: string) {
   if (getDesktopAPI()) {
     await createElectronProjectFS(uuid).deleteFileSystem();

--- a/utility/editor/src/core/services/systemplugin.ts
+++ b/utility/editor/src/core/services/systemplugin.ts
@@ -2,7 +2,7 @@ import { PathUtils } from '@zephyr3d/base';
 import { BlobReader, TextWriter, ZipReader, configure, type FileEntry } from '@zip.js/zip.js';
 import { libDir } from '../build/templates';
 import { installDeps } from '../build/dep';
-import { createSystemPluginVFS } from './storage';
+import { createLinkedDirectoryVFS, createSystemPluginVFS } from './storage';
 
 configure({ useWebWorkers: false });
 
@@ -21,6 +21,9 @@ export type SystemPluginManifestEntry = {
   description?: string;
   entry: string;
   dependencies?: Record<string, string>;
+  linked?: {
+    directory: string;
+  };
   enabled: boolean;
   installedAt: number;
   updatedAt: number;
@@ -81,6 +84,12 @@ export type InstallSystemPluginFilesInput = {
   enabled?: boolean;
 };
 
+export type LinkSystemPluginInput = {
+  directory: string;
+  entryFileName?: string;
+  enabled?: boolean;
+};
+
 export type SystemPluginFileRecord = {
   path: string;
   relativePath: string;
@@ -95,6 +104,9 @@ export type SystemPluginDirectoryRecord = {
 };
 
 export class SystemPluginService {
+  private static readonly _linkedPluginMounts = new Map<string, ReturnType<typeof createLinkedDirectoryVFS>>();
+  private static readonly _linkedPluginDirectories = new Map<string, string>();
+
   static get VFS() {
     return systemPluginVFS;
   }
@@ -121,16 +133,19 @@ export class SystemPluginService {
   }
 
   static async listPlugins(): Promise<SystemPluginRecord[]> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     return Object.values(manifest.plugins).map((plugin) => this.toRecord(plugin));
   }
 
   static async getPlugin(id: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     return manifest.plugins[id] ? this.toRecord(manifest.plugins[id]) : null;
   }
 
   static async getInstalledPluginSource(id: string): Promise<InstalledSystemPlugin | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     const plugin = manifest.plugins[id];
     if (!plugin) {
@@ -205,6 +220,7 @@ export class SystemPluginService {
   }
 
   static async findPluginByPath(path: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     const plugins = await this.listPlugins();
     for (const plugin of plugins) {
@@ -221,6 +237,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
@@ -254,6 +273,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin directory path must not be empty');
@@ -279,6 +301,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
     const oldPath = this.normalizePluginFilePath(oldRelativePath);
     const nextPath = this.normalizePluginFilePath(newRelativePath);
@@ -320,6 +345,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin file path must not be empty');
@@ -355,6 +383,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const oldPath = this.normalizePluginFilePath(oldRelativePath);
     const nextPath = this.normalizePluginFilePath(newRelativePath);
     if (!oldPath || !nextPath) {
@@ -388,6 +419,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin directory path must not be empty');
@@ -411,6 +445,7 @@ export class SystemPluginService {
   }
 
   static async getPluginByPath(path: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     for (const plugin of Object.values(manifest.plugins)) {
@@ -455,6 +490,8 @@ export class SystemPluginService {
     const oldEntry = manifest.plugins[packageManifest.id];
     const packageDir = this.getPackageDir(packageManifest.id);
 
+    await this.unmountLinkedPlugin(packageManifest.id);
+
     await systemPluginVFS.deleteDirectory(packageDir, true).catch(() => undefined);
     await systemPluginVFS.makeDirectory(packageDir, true);
     for (const file of normalizedFiles) {
@@ -478,6 +515,7 @@ export class SystemPluginService {
       dependencies: packageManifest.dependencies
         ? { ...packageManifest.dependencies }
         : oldEntry?.dependencies,
+      linked: undefined,
       enabled: input.enabled ?? true,
       installedAt: oldEntry?.installedAt ?? now,
       updatedAt: now
@@ -486,12 +524,78 @@ export class SystemPluginService {
     return this.toRecord(manifest.plugins[packageManifest.id]);
   }
 
+  static async linkPlugin(input: LinkSystemPluginInput): Promise<SystemPluginRecord> {
+    await this.ensureLayout();
+    const linkedInfo = await this.readLinkedPluginInput(input.directory, input.entryFileName);
+    const packageManifest = linkedInfo.packageManifest;
+    const entryFileName = linkedInfo.entryFileName;
+
+    const now = Date.now();
+    const manifest = await this.readManifest();
+    const oldEntry = manifest.plugins[packageManifest.id];
+    manifest.plugins[packageManifest.id] = {
+      id: packageManifest.id,
+      name: packageManifest.name,
+      version: packageManifest.version,
+      description: packageManifest.description,
+      entry: `/${entryFileName}`,
+      dependencies: packageManifest.dependencies,
+      linked: {
+        directory: input.directory
+      },
+      enabled: input.enabled ?? true,
+      installedAt: oldEntry?.installedAt ?? now,
+      updatedAt: now
+    };
+    await this.writeManifest(manifest);
+    await this.mountLinkedPlugin(this.toRecord(manifest.plugins[packageManifest.id]));
+    return this.toRecord(manifest.plugins[packageManifest.id]);
+  }
+
+  static async refreshLinkedPlugins(): Promise<SystemPluginRecord[]> {
+    await this.ensureLayout();
+    const manifest = await this.readManifest();
+    const refreshed: SystemPluginRecord[] = [];
+    let dirty = false;
+    for (const plugin of Object.values(manifest.plugins)) {
+      const directory = plugin.linked?.directory?.trim();
+      if (!directory) {
+        continue;
+      }
+      const linkedInfo = await this.readLinkedPluginInput(directory, plugin.entry.replace(/^\/+/, ''));
+      const nextManifest = linkedInfo.packageManifest;
+      const nextEntry = linkedInfo.entryFileName;
+      if (
+        plugin.name !== nextManifest.name ||
+        plugin.version !== nextManifest.version ||
+        plugin.description !== nextManifest.description ||
+        plugin.entry !== `/${nextEntry}` ||
+        JSON.stringify(plugin.dependencies ?? {}) !== JSON.stringify(nextManifest.dependencies ?? {})
+      ) {
+        plugin.name = nextManifest.name;
+        plugin.version = nextManifest.version;
+        plugin.description = nextManifest.description;
+        plugin.entry = `/${nextEntry}`;
+        plugin.dependencies = nextManifest.dependencies;
+        plugin.updatedAt = Date.now();
+        dirty = true;
+      }
+      refreshed.push(this.toRecord(plugin));
+    }
+    if (dirty) {
+      await this.writeManifest(manifest);
+    }
+    await this.syncLinkedPluginMounts();
+    return refreshed;
+  }
+
   static async removePlugin(id: string): Promise<void> {
     const manifest = await this.readManifest();
     const plugin = manifest.plugins[id];
     if (!plugin) {
       return;
     }
+    await this.unmountLinkedPlugin(id);
     delete manifest.plugins[id];
     await this.writeManifest(manifest);
     await systemPluginVFS.deleteDirectory(this.getPackageDir(id), true).catch(() => undefined);
@@ -636,6 +740,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' cannot install dependencies from the built-in plugin manager`);
+    }
     const match = spec.match(/^((?:@[^/]+\/)?[^@/]+)(?:@(.+))?$/);
     const packageName = match?.[1] ?? spec;
     const previousVersion = plugin.dependencies?.[packageName];
@@ -663,6 +770,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' cannot remove dependencies from the built-in plugin manager`);
     }
     const manifest = await this.readManifest();
     const manifestEntry = manifest.plugins[pluginId];
@@ -722,10 +832,14 @@ export class SystemPluginService {
 
   static async updatePluginFile(path: string, source: string): Promise<SystemPluginRecord> {
     await this.ensureLayout();
+    await this.syncLinkedPluginMounts();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     const plugin = await this.getPluginByPath(normalizedPath);
     if (!plugin) {
       throw new Error(`System plugin file '${path}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
 
     const manifest = await this.readManifest();
@@ -1124,6 +1238,10 @@ export class SystemPluginService {
         delete plugin.builtin;
         dirty = true;
       }
+      if (plugin.linked && typeof plugin.linked.directory !== 'string') {
+        delete plugin.linked;
+        dirty = true;
+      }
     }
     if (dirty) {
       await this.writeManifest(normalized);
@@ -1147,6 +1265,74 @@ export class SystemPluginService {
       settingsPath: this.getSettingsPath(plugin.id),
       depsRoot: this.getDependenciesRoot(plugin.id),
       depsLockPath: this.getDependenciesLockPath(plugin.id)
+    };
+  }
+
+  private static async syncLinkedPluginMounts() {
+    const manifest = await this.readManifest();
+    const linkedEntries = Object.values(manifest.plugins).filter((plugin) => !!plugin.linked?.directory);
+    const keepIds = new Set(linkedEntries.map((plugin) => plugin.id));
+    for (const id of [...this._linkedPluginMounts.keys()]) {
+      if (!keepIds.has(id)) {
+        await this.unmountLinkedPlugin(id);
+      }
+    }
+    for (const entry of linkedEntries) {
+      await this.mountLinkedPlugin(this.toRecord(entry));
+    }
+  }
+
+  private static async mountLinkedPlugin(plugin: SystemPluginRecord) {
+    const directory = plugin.linked?.directory?.trim();
+    if (!directory) {
+      await this.unmountLinkedPlugin(plugin.id);
+      return;
+    }
+    const currentDirectory = this._linkedPluginDirectories.get(plugin.id);
+    if (currentDirectory === directory && this._linkedPluginMounts.has(plugin.id)) {
+      return;
+    }
+    await this.unmountLinkedPlugin(plugin.id);
+    const vfs = createLinkedDirectoryVFS(directory);
+    await systemPluginVFS.mount(this.getPackageDir(plugin.id), vfs);
+    this._linkedPluginMounts.set(plugin.id, vfs);
+    this._linkedPluginDirectories.set(plugin.id, directory);
+  }
+
+  private static async unmountLinkedPlugin(id: string) {
+    if (this._linkedPluginMounts.has(id)) {
+      await systemPluginVFS.unmount(this.getPackageDir(id)).catch(() => false);
+      const vfs = this._linkedPluginMounts.get(id);
+      this._linkedPluginMounts.delete(id);
+      this._linkedPluginDirectories.delete(id);
+      await vfs?.close?.();
+    }
+  }
+
+  private static async readLinkedPluginInput(directory: string, entryFileName?: string) {
+    const linkedVFS = createLinkedDirectoryVFS(directory);
+    const files = await linkedVFS.readDirectory('/', {
+      includeHidden: true,
+      recursive: true
+    });
+    const inputFiles: SystemPluginFileInput[] = [];
+    for (const item of files) {
+      if (item.type !== 'file') {
+        continue;
+      }
+      inputFiles.push({
+        path: linkedVFS.relative(item.path, '/'),
+        source: (await linkedVFS.readFile(item.path, { encoding: 'utf8' })) as string
+      });
+    }
+    const packageFiles = this.normalizeImportedPluginFiles(inputFiles);
+    const packageManifest = this.readPackageManifestFromFiles(packageFiles);
+    const normalizedEntryFileName = this.normalizeEntryFileName(entryFileName ?? packageManifest.entry);
+    this.validatePluginFiles(packageFiles, normalizedEntryFileName, packageManifest.id);
+    await linkedVFS.close();
+    return {
+      packageManifest,
+      entryFileName: normalizedEntryFileName
     };
   }
 }

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -7,6 +7,7 @@ import type { SystemPluginRecord } from '../../core/services/systemplugin';
 import { FilePicker } from '../../components/filepicker';
 import { templateEditorPluginFiles } from '../../core/build/templates';
 import { SystemPluginService } from '../../core/services/systemplugin';
+import { getDesktopAPI } from '../../core/services/desktop';
 import { DlgPromptName } from './promptnamedlg';
 import { DlgMessageBoxEx } from './messageexdlg';
 import { Dialog } from './dlg';
@@ -36,6 +37,12 @@ function getPluginDependencySummary(plugin: SystemPluginRecord): string {
     return 'Dependencies: none';
   }
   return `Dependencies: ${dependencies.map(([name, version]) => `${name}@${version}`).join(', ')}`;
+}
+
+function getPluginModeSummary(plugin: SystemPluginRecord): string {
+  return plugin.linked?.directory
+    ? `Mode: linked (${plugin.linked.directory})`
+    : 'Mode: installed package';
 }
 
 function normalizePluginSettingsForSchema(
@@ -173,6 +180,7 @@ class SystemPluginListView extends ListView<{}, SystemPluginRecord> {
         item.description ? '' : null,
         `Id: ${item.id}`,
         `Entry: ${item.entry}`,
+        getPluginModeSummary(item),
         ...((item.description || item.entry) && Object.keys(item.dependencies ?? {}).length > 0 ? [''] : []),
         ...getPluginDependencyLines(item)
       ]
@@ -416,12 +424,15 @@ class DlgPluginFiles extends DialogRenderer<void> {
 
   doRender(): void {
     ImGui.Text(`Plugin: ${this._plugin.id}`);
+    if (this._plugin.linked?.directory) {
+      ImGui.TextDisabled(`Linked to: ${this._plugin.linked.directory}`);
+    }
     ImGui.Separator();
-    if (ImGui.Button('Install Package...')) {
+    if (ImGui.Button('Install Package...') && !this._plugin.linked?.directory) {
       this.installPackage();
     }
     ImGui.SameLine();
-    if (ImGui.Button('Remove Package...')) {
+    if (ImGui.Button('Remove Package...') && !this._plugin.linked?.directory) {
       this.removePackage();
     }
     ImGui.Separator();
@@ -727,12 +738,19 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       ImGui.SetTooltip('Installs a plugin from directory');
     }
     ImGui.SameLine();
+    if (ImGui.Button('Link...') && !this._busy) {
+      this.linkPlugin();
+    }
+    if (ImGui.IsItemHovered()) {
+      ImGui.SetTooltip('Links a desktop plugin to an external dist directory for development');
+    }
+    ImGui.SameLine();
     if (ImGui.Button('New Template...') && !this._busy) {
       this.createTemplatePlugin();
     }
     ImGui.SameLine();
     if (ImGui.Button('Refresh') && !this._busy) {
-      this.reload().catch(() => undefined);
+      this.refreshPlugins().catch(() => undefined);
     }
 
     ImGui.Separator();
@@ -755,17 +773,18 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
         this.browseFiles(selected);
       }
       ImGui.SameLine();
-      if (ImGui.Button('Install Package...') && !this._busy) {
+      if (ImGui.Button('Install Package...') && !this._busy && !selected.linked?.directory) {
         this.installPluginPackage(selected);
       }
       ImGui.SameLine();
-      if (ImGui.Button('Remove Package...') && !this._busy) {
+      if (ImGui.Button('Remove Package...') && !this._busy && !selected.linked?.directory) {
         this.removePluginPackage(selected);
       }
       ImGui.SameLine();
       if (ImGui.Button('Settings...') && !this._busy) {
         this.editPluginSettings(selected);
       }
+      ImGui.TextWrapped(getPluginModeSummary(selected));
       ImGui.TextWrapped(getPluginDependencySummary(selected));
     } else {
       ImGui.TextDisabled('Select a plugin to inspect or remove it.');
@@ -779,6 +798,16 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
 
   private async reload() {
     this._listData.elements = await this._editor.listSystemPlugins();
+  }
+
+  private async refreshPlugins() {
+    this._busy = true;
+    try {
+      this._listData.elements = await this._editor.refreshSystemPlugins();
+    } catch {
+    } finally {
+      this._busy = false;
+    }
   }
 
   private async installPlugin() {
@@ -801,6 +830,27 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       const files = await FilePicker.chooseDirectory();
       if (files?.length) {
         await this._editor.installSystemPluginFromDirectory(files);
+        await this.reload();
+      }
+    } catch {
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  private async linkPlugin() {
+    const desktop = getDesktopAPI();
+    if (!desktop?.fs?.pickDirectory) {
+      return;
+    }
+    this._busy = true;
+    try {
+      const directory = await desktop.fs.pickDirectory({
+        title: 'Select Plugin Dist Directory',
+        buttonLabel: 'Link Plugin'
+      });
+      if (directory) {
+        await this._editor.linkSystemPlugin(directory, 'index.js');
         await this.reload();
       }
     } catch {

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -45,6 +45,10 @@ function getPluginModeSummary(plugin: SystemPluginRecord): string {
     : 'Mode: installed package';
 }
 
+const AUTO_SCRIPT_PATHS_BY_PLUGIN_ID: Record<string, string[]> = {
+  'com.0yao.zephyr3d-plugin': ['/assets/scripts/gpucloth.ts', '/assets/scripts/springtest.ts']
+};
+
 function normalizePluginSettingsForSchema(
   schema: EditorPluginSettingsSchema,
   settings: Record<string, unknown> | null | undefined
@@ -925,7 +929,37 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
   private async removeSelected(plugin: SystemPluginRecord) {
     this._busy = true;
     try {
+      const autoScriptPaths = AUTO_SCRIPT_PATHS_BY_PLUGIN_ID[plugin.id] ?? [];
+      let shouldDeleteScripts = false;
+      if (autoScriptPaths.length > 0 && this._editor.currentProject && !this._editor.isProjectReadOnly()) {
+        const existingPaths: string[] = [];
+        for (const path of autoScriptPaths) {
+          if (await this._editor.projectFileExists(path)) {
+            existingPaths.push(path);
+          }
+        }
+        if (existingPaths.length > 0) {
+          const confirmed = await DlgMessageBoxEx.messageBoxEx(
+            'Remove plugin scripts',
+            `Also remove these generated project scripts?\n\n${existingPaths.join('\n')}`,
+            ['Remove Plugin And Scripts', 'Keep Scripts', 'Cancel'],
+            460,
+            0,
+            true
+          );
+          if (confirmed === 'Cancel') {
+            return;
+          }
+          shouldDeleteScripts = confirmed === 'Remove Plugin And Scripts';
+          if (shouldDeleteScripts) {
+            for (const path of existingPaths) {
+              await this._editor.deleteProjectFile(path);
+            }
+          }
+        }
+      }
       await this._editor.removeSystemPlugin(plugin.id);
+      void shouldDeleteScripts;
       await this.reload();
     } catch {
     } finally {


### PR DESCRIPTION
## 变更范围
- 桌面开发态启动脚本
- 桌面插件 link 模式
- 插件开发模式与脚本清理逻辑

## 变更目标
为桌面端插件开发提供更顺手的本地开发工作流基础能力。

## 主要改动
- 增加桌面端开发态一键启动能力
- 增加桌面端插件开发态 link 模式
- 支持插件开发模式切换与脚本清理

## 测试方式
- 运行桌面开发态启动流程
- 链接本地插件目录
- 验证开发模式切换与脚本清理行为是否正常