### PR TITLE
支持插件源码 Link 模式并优化加载进度提示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ utility/editor/release/
 
 # VSCodeCounter
 .VSCodeCounter
+/AGENTS.md

--- a/apps/doc/web/zh-cn/editor/plugins.md
+++ b/apps/doc/web/zh-cn/editor/plugins.md
@@ -20,6 +20,7 @@
 
 - `Install...`：从 `.zip` 插件包安装
 - `Install Folder...`：从未打包的插件目录安装
+- `Link...`：在桌面端将插件根目录直接链接到编辑器，供开发调试使用
 - `New Template...`：在编辑器里生成一个起步模板插件
 
 插件安装后，可以继续：
@@ -29,6 +30,12 @@
 - 使用 `Install Package...` 安装第三方 npm 依赖
 - 使用 `Settings...` 配置插件暴露出的设置项
 - 将插件从编辑器中移除
+
+说明：
+
+- `Install...` 和 `Install Folder...` 面向正式安装/发布使用
+- `Link...` 仅用于桌面端开发模式，不适用于浏览器版编辑器
+- `Link...` 链接的是插件根目录，不是 `src/`，也不是 `dist/`
 
 ---
 
@@ -64,6 +71,91 @@ my-editor-plugin/
 - `entry`：必填，表示插件入口模块的相对路径
 - `name`、`version`、`description`：可选，但建议填写
 - `dependencies`：可选，声明插件使用的第三方包
+
+---
+
+## 桌面端开发模式
+
+桌面端开发模式支持让编辑器直接读取插件源码，而不是先构建 `dist` 再安装。
+
+推荐目录结构如下：
+
+```text
+my-editor-plugin/
+  plugin.dev.json
+  plugin.json
+  src/
+    index.ts
+  libs/
+    deps.lock.json
+    deps/
+  dist/
+    index.js
+    plugin.json
+```
+
+其中：
+
+- `plugin.dev.json`：开发态清单，供桌面端 `Link...` 使用
+- `plugin.json`：发布态清单，供正式安装包或 `dist` 产物使用
+- `src/`：插件源码入口
+- `libs/deps/`：编辑器为开发态插件缓存的第三方依赖
+- `dist/`：构建后的发布产物
+
+开发态示例 `plugin.dev.json`：
+
+```json
+{
+  "id": "com.example.demo-plugin",
+  "name": "Demo Plugin",
+  "version": "0.1.0",
+  "description": "Example editor plugin for Zephyr3d.",
+  "entry": "src/index.ts",
+  "dependencies": {
+    "nanoid": "^5.0.0"
+  }
+}
+```
+
+开发流程：
+
+1. 启动桌面版编辑器开发环境
+2. 打开 `Project -> Plugin Manager...`
+3. 点击 `Link...`
+4. 选择插件根目录
+5. 修改源码后，手动点击 `Refresh`
+
+开发态特点：
+
+- 编辑器直接加载 `src` 下源码，不需要先执行 `npm install`
+- 如果 `plugin.dev.json` 的 `dependencies` 声明了第三方包，编辑器会在首次需要时自动下载并缓存到 `libs/deps/`
+- 后续刷新会优先复用本地 `libs/deps` 和 `libs/deps.lock.json`
+- 开发态 `Refresh` 只会重新校验 `plugin.dev.json` 和入口依赖图，不会递归扫描整个插件目录
+
+注意事项：
+
+- 开发态第三方包必须声明在 `plugin.dev.json.dependencies` 中
+- `Link...` 后插件源码变更不会自动热重载，需要手动点击 `Refresh`
+- 如果首次下载依赖时离线，且本地又没有 `libs/deps` 缓存，则插件加载会失败
+
+---
+
+## 发布模式
+
+发布时仍然建议使用传统的安装包/构建产物流程。
+
+发布流程：
+
+1. 安装插件构建依赖
+2. 执行构建，生成 `dist/`
+3. 确认 `dist/plugin.json` 与 `dist/index.js` 等产物完整
+4. 使用 `Install...` 安装 `.zip` 包，或使用 `Install Folder...` 安装发布目录
+
+发布态特点：
+
+- 使用构建后的 JavaScript 产物，加载速度通常快于开发态源码模式
+- 更适合分发给其他人或用于稳定版本交付
+- `plugin.json` 应描述发布态入口，例如 `dist/index.js` 或发布目录内入口文件
 
 ---
 
@@ -239,4 +331,10 @@ import { nanoid } from 'nanoid';
 ```
 
 已安装包的版本会同步记录到 `plugin.json` 的 `dependencies` 字段中。
+
+对于桌面端开发态插件：
+
+- 优先在 `plugin.dev.json` 中声明 `dependencies`
+- 点击 `Refresh` 时，编辑器会自动同步缺失依赖到 `libs/deps/`
+- 一般不需要先手动执行 `npm install`
 

--- a/libs/scene/src/app/scriptregistry.ts
+++ b/libs/scene/src/app/scriptregistry.ts
@@ -41,6 +41,40 @@ function isBareModule(spec: string) {
   return !spec.startsWith('./') && !spec.startsWith('../') && !spec.startsWith('/') && !spec.startsWith('#/');
 }
 
+function splitSpecifierQuery(spec: string) {
+  const hashIndex = spec.indexOf('#');
+  const queryIndex = spec.indexOf('?');
+  const cutIndex =
+    queryIndex >= 0 && hashIndex >= 0
+      ? Math.min(queryIndex, hashIndex)
+      : queryIndex >= 0
+        ? queryIndex
+        : hashIndex;
+  if (cutIndex < 0) {
+    return {
+      path: spec,
+      suffix: ''
+    };
+  }
+  return {
+    path: spec.slice(0, cutIndex),
+    suffix: spec.slice(cutIndex)
+  };
+}
+
+function hasRawQuery(spec: string) {
+  const { suffix } = splitSpecifierQuery(spec);
+  if (!suffix || suffix[0] !== '?') {
+    return false;
+  }
+  const queryEnd = suffix.indexOf('#');
+  const query = (queryEnd >= 0 ? suffix.slice(1, queryEnd) : suffix.slice(1)).trim();
+  if (!query) {
+    return false;
+  }
+  return query.split('&').some((part) => part.trim() === 'raw');
+}
+
 type ScriptModuleType = 'js' | 'ts';
 
 type ScriptModuleInfo = {
@@ -354,7 +388,9 @@ export class ScriptRegistry {
     modules.set(module.id, module);
 
     const source = (await this._vfs.readFile(module.path, { encoding: 'utf8' })) as string;
-    const esmCode = await this.transpileToESModule(source, module.id, module.type);
+    const esmCode = hasRawQuery(module.id)
+      ? `export default ${JSON.stringify(source)};\n`
+      : await this.transpileToESModule(source, module.id, module.type);
     const rewritten = await this.rewriteImportsToLogicalIds(esmCode, module.id);
     module.deps = rewritten.deps;
     module.systemCode = await this.transpileToSystemModule(rewritten.code, module.id);
@@ -370,9 +406,10 @@ export class ScriptRegistry {
     if (!srcPath) {
       return null;
     }
+    const { suffix } = splitSpecifierQuery(String(id));
     const path = this._vfs.normalizePath(srcPath.path);
     return {
-      id: path,
+      id: `${path}${suffix}`,
       path,
       type: srcPath.type,
       deps: [],
@@ -590,27 +627,27 @@ async function __z3dLoad(spec, parentId = '') {
    * @throws If a relative import is provided without `fromId`.
    */
   async resolveLogicalId(spec: string, fromId?: string) {
-    if (spec.startsWith('#/')) {
-      return this._vfs.normalizePath(this._vfs.join(this._scriptsRoot, spec.slice(2)));
-    } else if (spec.startsWith('./') || spec.startsWith('../')) {
+    const { path: baseSpec, suffix } = splitSpecifierQuery(spec);
+    if (baseSpec.startsWith('#/')) {
+      return `${this._vfs.normalizePath(this._vfs.join(this._scriptsRoot, baseSpec.slice(2)))}${suffix}`;
+    } else if (baseSpec.startsWith('./') || baseSpec.startsWith('../')) {
       if (!fromId) {
         throw new Error(`Relative import "${spec}" requires fromId`);
       }
-      return this._vfs.normalizePath(
-        this._vfs.join(this._vfs.dirname(this._vfs.normalizePath(fromId)), spec)
-      );
-    } else if (spec.startsWith('/')) {
-      return spec.replace(/^\/+/, '/');
+      const fromPath = splitSpecifierQuery(this._vfs.normalizePath(fromId)).path;
+      return `${this._vfs.normalizePath(this._vfs.join(this._vfs.dirname(fromPath), baseSpec))}${suffix}`;
+    } else if (baseSpec.startsWith('/')) {
+      return `${baseSpec.replace(/^\/+/, '/')}${suffix}`;
     } else if (getApp().editorMode !== 'none') {
-      const libRoot = '/';
+      const libRoot = this._vfs.normalizePath(this._scriptsRoot || '/');
       // naked module, checking if it is a installed module in editor mode
       let depsLockPath = this._vfs.normalizePath(this._vfs.join(libRoot, 'libs/deps.lock.json'));
       let depsExists = await this._vfs.exists(depsLockPath);
       if (depsExists) {
         const content = (await this._vfs.readFile(depsLockPath, { encoding: 'utf8' })) as string;
         const depsInfo = JSON.parse(content) as { dependencies: Record<string, { entry: string }> };
-        if (depsInfo?.dependencies[spec]) {
-          return this._vfs.normalizePath(this._vfs.join(libRoot, depsInfo.dependencies[spec].entry));
+        if (depsInfo?.dependencies[baseSpec]) {
+          return `${this._vfs.normalizePath(this._vfs.join(libRoot, depsInfo.dependencies[baseSpec].entry))}${suffix}`;
         }
       }
     }
@@ -629,13 +666,14 @@ async function __z3dLoad(spec, parentId = '') {
    * @returns `{ type, path }` or `null` if not found.
    */
   async resolveSourcePath(logicalId: string) {
+    const { path: normalizedLogicalId } = splitSpecifierQuery(logicalId);
     let type: Nullable<'js' | 'ts'> = null;
     let pathWithExt = '';
-    if (logicalId.endsWith('.ts')) {
-      pathWithExt = logicalId;
+    if (normalizedLogicalId.endsWith('.ts')) {
+      pathWithExt = normalizedLogicalId;
       type = 'ts';
-    } else if (logicalId.endsWith('.js') || logicalId.endsWith('.mjs')) {
-      pathWithExt = logicalId;
+    } else if (normalizedLogicalId.endsWith('.js') || normalizedLogicalId.endsWith('.mjs')) {
+      pathWithExt = normalizedLogicalId;
       type = 'js';
     }
     if (type) {
@@ -651,7 +689,7 @@ async function __z3dLoad(spec, parentId = '') {
     const types = ['ts', 'js', 'mjs'] as const;
     if (!type) {
       for (const t of types) {
-        pathWithExt = `${logicalId}.${t}`;
+        pathWithExt = `${normalizedLogicalId}.${t}`;
         const exists = await this._vfs.exists(pathWithExt);
         if (exists) {
           const stats = await this._vfs.stat(pathWithExt);

--- a/utility/editor/README.md
+++ b/utility/editor/README.md
@@ -160,6 +160,26 @@ The plugin API supports:
 - project storage and system plugin state/settings
 - editor event subscriptions
 
+### Desktop Plugin Development
+
+The Electron desktop editor supports linking a plugin root directory directly for source-based development.
+
+Recommended development setup:
+
+- Keep a `plugin.dev.json` at the plugin root for desktop development
+- Point its `entry` to a source file such as `src/index.ts`
+- Declare third-party runtime packages in `plugin.dev.json.dependencies`
+- Use `Project -> Plugin Manager... -> Link...` and choose the plugin root directory
+- After editing source files, click `Refresh` in Plugin Manager to reload the linked plugin
+
+In this mode:
+
+- the editor loads plugin source directly instead of requiring a prebuilt `dist`
+- missing third-party dependencies are cached under the plugin's local `libs/deps/`
+- plugin refresh validates the manifest and entry dependency graph instead of scanning the entire plugin folder
+
+For release builds, continue using the packaged `plugin.json` and built `dist` output.
+
 ## Related Links
 
 - Repository: https://github.com/gavinyork/zephyr3d

--- a/utility/editor/README.md
+++ b/utility/editor/README.md
@@ -46,6 +46,18 @@ Build and launch the Electron desktop app for development:
 npm run electron:dev --prefix utility/editor
 ```
 
+Install a Windows desktop shortcut for the development runtime:
+
+```sh
+npm run electron:dev:install-shortcut --prefix utility/editor
+```
+
+Launch the development runtime through the shortcut-compatible launcher:
+
+```sh
+npm run electron:dev:launch --prefix utility/editor
+```
+
 Launch the Electron app from an existing build:
 
 ```sh
@@ -65,6 +77,22 @@ The Electron build is an additive desktop runtime for the browser editor.
 - Browser builds continue to use the existing VFS abstraction and browser storage.
 - Desktop builds expose a constrained preload bridge instead of direct Node.js access in renderer code.
 - Editor metadata, system plugins, and local projects are stored under Electron `app.getPath('userData')/editor-storage`.
+
+## Windows Dev Shortcut
+
+The Windows development shortcut launches `utility/editor/scripts/launch-electron-dev.ps1`, which starts the same dev runtime as `npm run electron:dev`.
+
+- The first launch starts the Vite dev server and the Electron shell in the background.
+- Launching the shortcut again reuses the existing dev runtime when it is already running.
+- If the editor window was closed accidentally while the dev runtime is still alive, launching the shortcut again opens a new Electron window against the same dev server.
+- Runtime state and launcher logs are stored under `%LOCALAPPDATA%\Zephyr3DEditor\dev-runtime`. If that location is not writable, the launcher falls back to `utility/editor/.dev-runtime`.
+
+Development shortcut update behavior:
+
+- Changes under `utility/editor/src` update through the Vite dev server, usually with HMR or an automatic page reload.
+- Changes under `utility/editor/electron`, `utility/editor/mcp`, and `utility/editor/package.json` trigger an Electron process restart.
+- Changes under `libs/base`, `libs/device`, `libs/scene`, `libs/loaders`, `libs/backend-webgl`, and `libs/backend-webgpu` are wired to source in dev mode and should refresh into the running desktop editor.
+- Packaged desktop builds created by `npm run electron:dist` do not track source changes automatically. Rebuild or repackage them after code changes.
 
 ## MCP Integration
 

--- a/utility/editor/electron/README.md
+++ b/utility/editor/electron/README.md
@@ -16,6 +16,14 @@ npm run build --prefix utility/editor
 npm run electron:start --prefix utility/editor
 ```
 
+Windows development shortcut:
+
+```sh
+npm run electron:dev:install-shortcut --prefix utility/editor
+```
+
+This creates a desktop shortcut named `Zephyr3D Editor (Dev).lnk` that launches the development runtime without opening a terminal window.
+
 Packaging:
 
 ```sh

--- a/utility/editor/package.json
+++ b/utility/editor/package.json
@@ -41,6 +41,8 @@
     "deploy": "npm run build && shx rm -rf ../../apps/homepage/editor && shx cp -R dist ../../apps/homepage/editor",
     "electron:start": "electron .",
     "electron:dev": "node ./scripts/electron-dev.cjs",
+    "electron:dev:launch": "node ./scripts/launch-electron-dev.cjs",
+    "electron:dev:install-shortcut": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/install-desktop-shortcut.ps1",
     "electron:prepare": "node ./scripts/prepare-electron-app.cjs",
     "electron:pack": "rush build -t editor && npm run electron:prepare && electron-builder --projectDir .electron-app --config ../electron-builder.json --dir",
     "electron:dist": "rush build -t editor && npm run electron:prepare && electron-builder --projectDir .electron-app --config ../electron-builder.json",

--- a/utility/editor/scripts/dev-runtime-state.cjs
+++ b/utility/editor/scripts/dev-runtime-state.cjs
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function normalizeEditorRoot(editorRoot) {
+  return path.resolve(editorRoot);
+}
+
+function toStateKey(editorRoot) {
+  const normalizedRoot = normalizeEditorRoot(editorRoot);
+  return normalizedRoot.replace(/[^a-zA-Z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || 'default';
+}
+
+function canUseDirectory(dirPath) {
+  try {
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.accessSync(dirPath, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getRuntimeBaseDir(editorRoot) {
+  const explicitDir =
+    typeof process.env.ZEPHYR_EDITOR_DEV_RUNTIME_DIR === 'string' ? process.env.ZEPHYR_EDITOR_DEV_RUNTIME_DIR.trim() : '';
+  const candidates = [];
+  if (explicitDir) {
+    candidates.push(path.resolve(explicitDir));
+  }
+  if (process.env.LOCALAPPDATA) {
+    candidates.push(path.join(process.env.LOCALAPPDATA, 'Zephyr3DEditor', 'dev-runtime'));
+  }
+  candidates.push(path.join(normalizeEditorRoot(editorRoot), '.dev-runtime'));
+  candidates.push(path.join(os.tmpdir(), 'Zephyr3DEditor', 'dev-runtime'));
+
+  for (const candidate of candidates) {
+    if (candidate && canUseDirectory(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error('Could not find a writable directory for the Zephyr3D Editor dev runtime state.');
+}
+
+function getRuntimeStateDir(editorRoot) {
+  return path.join(getRuntimeBaseDir(editorRoot), toStateKey(editorRoot));
+}
+
+function ensureRuntimeStateDir(editorRoot) {
+  const stateDir = getRuntimeStateDir(editorRoot);
+  fs.mkdirSync(stateDir, { recursive: true });
+  return stateDir;
+}
+
+function getRuntimeStateFilePath(editorRoot) {
+  return path.join(getRuntimeStateDir(editorRoot), 'state.json');
+}
+
+function getRuntimeLogFilePath(editorRoot) {
+  return path.join(getRuntimeStateDir(editorRoot), 'launcher.log');
+}
+
+function readRuntimeState(editorRoot) {
+  try {
+    return JSON.parse(fs.readFileSync(getRuntimeStateFilePath(editorRoot), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeRuntimeState(editorRoot, state) {
+  ensureRuntimeStateDir(editorRoot);
+  const filePath = getRuntimeStateFilePath(editorRoot);
+  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+function clearRuntimeState(editorRoot) {
+  try {
+    fs.rmSync(getRuntimeStateFilePath(editorRoot), { force: true });
+  } catch {
+    // Ignore stale state cleanup errors.
+  }
+}
+
+function clearRuntimeStateIfOwned(editorRoot, runnerPid) {
+  const state = readRuntimeState(editorRoot);
+  if (state?.runnerPid === runnerPid) {
+    clearRuntimeState(editorRoot);
+  }
+}
+
+module.exports = {
+  clearRuntimeState,
+  clearRuntimeStateIfOwned,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  getRuntimeStateDir,
+  getRuntimeStateFilePath,
+  readRuntimeState,
+  writeRuntimeState
+};

--- a/utility/editor/scripts/electron-dev.cjs
+++ b/utility/editor/scripts/electron-dev.cjs
@@ -3,6 +3,13 @@ const http = require('http');
 const https = require('https');
 const path = require('path');
 const { spawn } = require('child_process');
+const {
+  clearRuntimeStateIfOwned,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  readRuntimeState,
+  writeRuntimeState
+} = require('./dev-runtime-state.cjs');
 
 const projectRoot = path.resolve(__dirname, '..');
 const explicitDevUrl = process.env.ZEPHYR_EDITOR_ELECTRON_URL || '';
@@ -45,9 +52,16 @@ let restartTimer = null;
 let restartPromise = null;
 let pendingRestartReason = '';
 const fileWatchers = [];
+const runtimeLogPath = getRuntimeLogFilePath(projectRoot);
+const runtimeStateDir = ensureRuntimeStateDir(projectRoot);
 
 function log(message) {
   process.stdout.write(`[electron:dev] ${message}\n`);
+  try {
+    fs.appendFileSync(runtimeLogPath, `[${new Date().toISOString()}] [electron:dev] ${message}\n`, 'utf8');
+  } catch {
+    // Ignore diagnostic log write failures.
+  }
 }
 
 function stripAnsi(text) {
@@ -155,7 +169,26 @@ async function cleanup(exitCode = 0) {
   }
   closeWatchers();
   await Promise.all([terminateChild(electronProcess), terminateChild(serverProcess)]);
+  clearRuntimeStateIfOwned(projectRoot, process.pid);
   process.exit(exitCode);
+}
+
+function persistRuntimeState() {
+  const current = readRuntimeState(projectRoot);
+  if (current?.runnerPid && current.runnerPid !== process.pid) {
+    return;
+  }
+  writeRuntimeState(projectRoot, {
+    version: 1,
+    status: shuttingDown ? 'stopping' : 'running',
+    editorRoot: projectRoot,
+    runnerPid: process.pid,
+    serverPid: serverProcess?.pid ?? null,
+    electronPid: electronProcess?.pid ?? null,
+    devUrl,
+    logPath: runtimeLogPath,
+    updatedAt: new Date().toISOString()
+  });
 }
 
 function waitForDevServer(rawUrl, timeoutMs) {
@@ -233,6 +266,7 @@ async function startDevServer() {
 
     pipeOutput(serverProcess.stdout, process.stdout, handleOutputLine);
     pipeOutput(serverProcess.stderr, process.stderr, handleOutputLine);
+    persistRuntimeState();
 
     serverProcess.on('error', finishReject);
     serverProcess.on('exit', (code) => {
@@ -255,6 +289,7 @@ async function startDevServer() {
   } else {
     log(`Vite dev server ready at ${devUrl}`);
   }
+  persistRuntimeState();
 }
 
 function startElectron() {
@@ -271,6 +306,7 @@ function startElectron() {
   });
 
   electronProcess = child;
+  persistRuntimeState();
 
   child.on('error', (error) => {
     console.error(error);
@@ -281,6 +317,7 @@ function startElectron() {
     if (electronProcess === child) {
       electronProcess = null;
     }
+    persistRuntimeState();
     if (!shuttingDown) {
       if (restartingElectron) {
         return;
@@ -309,6 +346,7 @@ async function performElectronRestart(reason) {
   if (!shuttingDown) {
     startElectron();
   }
+  persistRuntimeState();
 }
 
 function queueElectronRestart(reason) {
@@ -398,15 +436,18 @@ function startWatchers() {
 }
 
 async function main() {
+  persistRuntimeState();
   if (!explicitDevUrl) {
     await startDevServer();
   } else {
     log(`Using external dev server ${devUrl}`);
+    persistRuntimeState();
   }
 
   await waitForDevServer(devUrl, 120000);
   startElectron();
   startWatchers();
+  log(`Runtime state is tracked under ${runtimeStateDir}`);
 }
 
 process.on('SIGINT', () => {

--- a/utility/editor/scripts/install-desktop-shortcut.ps1
+++ b/utility/editor/scripts/install-desktop-shortcut.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param(
+  [string]$ShortcutPath = (Join-Path ([Environment]::GetFolderPath('Desktop')) 'Zephyr3D Editor (Dev).lnk')
+)
+
+$editorRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$launcherScript = (Resolve-Path (Join-Path $PSScriptRoot 'launch-electron-dev.ps1')).Path
+$iconPath = (Resolve-Path (Join-Path $editorRoot 'electron\icon.ico')).Path
+$powershellExe = (Get-Command powershell.exe -ErrorAction Stop).Source
+
+$shortcutDirectory = Split-Path -Parent $ShortcutPath
+if ($shortcutDirectory) {
+  New-Item -ItemType Directory -Force -Path $shortcutDirectory | Out-Null
+}
+
+$shell = New-Object -ComObject WScript.Shell
+$shortcut = $shell.CreateShortcut($ShortcutPath)
+$shortcut.TargetPath = $powershellExe
+$shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcherScript`""
+$shortcut.WorkingDirectory = $editorRoot
+$shortcut.IconLocation = $iconPath
+$shortcut.Description = 'Launches the Zephyr3D Editor Electron dev runtime for this workspace.'
+$shortcut.Save()
+
+Write-Output "Created shortcut: $ShortcutPath"

--- a/utility/editor/scripts/launch-electron-dev.cjs
+++ b/utility/editor/scripts/launch-electron-dev.cjs
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const {
+  clearRuntimeState,
+  ensureRuntimeStateDir,
+  getRuntimeLogFilePath,
+  readRuntimeState,
+  writeRuntimeState
+} = require('./dev-runtime-state.cjs');
+
+const editorRoot = path.resolve(__dirname, '..');
+const devRunnerScript = path.join(__dirname, 'electron-dev.cjs');
+
+function isPidRunning(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveElectronBinary() {
+  try {
+    return require('electron');
+  } catch {
+    throw new Error('Electron dependency is not installed. Run npm install or rush update first.');
+  }
+}
+
+function appendLauncherLog(logPath, message) {
+  fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`, 'utf8');
+}
+
+function launchElectronInstance(existingState) {
+  const electronBinary = resolveElectronBinary();
+  const env = {
+    ...process.env
+  };
+  if (existingState?.devUrl) {
+    env.ZEPHYR_EDITOR_ELECTRON_URL = existingState.devUrl;
+  }
+  const child = spawn(electronBinary, ['.'], {
+    cwd: editorRoot,
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env
+  });
+  child.unref();
+}
+
+function startDetachedDevRunner() {
+  ensureRuntimeStateDir(editorRoot);
+  const logPath = getRuntimeLogFilePath(editorRoot);
+  const logFd = fs.openSync(logPath, 'a');
+  appendLauncherLog(logPath, 'Starting detached Electron dev runner');
+  const child = spawn(process.execPath, [devRunnerScript], {
+    cwd: editorRoot,
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    windowsHide: true,
+    env: {
+      ...process.env
+    }
+  });
+  child.unref();
+  fs.closeSync(logFd);
+  writeRuntimeState(editorRoot, {
+    version: 1,
+    status: 'launching',
+    editorRoot,
+    runnerPid: child.pid,
+    serverPid: null,
+    electronPid: null,
+    devUrl: '',
+    logPath,
+    updatedAt: new Date().toISOString()
+  });
+}
+
+function main() {
+  const existingState = readRuntimeState(editorRoot);
+  if (existingState?.runnerPid && isPidRunning(existingState.runnerPid)) {
+    if ((existingState.electronPid && isPidRunning(existingState.electronPid)) || existingState.devUrl) {
+      launchElectronInstance(existingState);
+    }
+    return;
+  }
+  clearRuntimeState(editorRoot);
+  startDetachedDevRunner();
+}
+
+try {
+  main();
+} catch (error) {
+  const stateDir = ensureRuntimeStateDir(editorRoot);
+  const logPath = getRuntimeLogFilePath(editorRoot);
+  appendLauncherLog(logPath, `Launcher failed: ${error?.stack || error}`);
+  process.stderr.write(`Failed to launch Zephyr3D Editor dev runtime. See ${path.join(stateDir, path.basename(logPath))}\n`);
+  process.stderr.write(`${error?.message || error}\n`);
+  process.exit(1);
+}

--- a/utility/editor/scripts/launch-electron-dev.ps1
+++ b/utility/editor/scripts/launch-electron-dev.ps1
@@ -1,0 +1,31 @@
+Add-Type -AssemblyName PresentationFramework
+
+function Show-LauncherError([string]$Message) {
+  [System.Windows.MessageBox]::Show(
+    $Message,
+    'Zephyr3D Editor (Dev)',
+    [System.Windows.MessageBoxButton]::OK,
+    [System.Windows.MessageBoxImage]::Error
+  ) | Out-Null
+}
+
+$editorRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$launcherPath = (Resolve-Path (Join-Path $PSScriptRoot 'launch-electron-dev.cjs')).Path
+$nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+
+if (-not $nodeCommand) {
+  Show-LauncherError 'Node.js was not found in PATH. Install Node.js first, then rerun the shortcut.'
+  exit 1
+}
+
+try {
+  $process = Start-Process -FilePath $nodeCommand.Source -ArgumentList @($launcherPath) -WorkingDirectory $editorRoot -WindowStyle Hidden -PassThru
+  $process.WaitForExit()
+  if ($process.ExitCode -ne 0) {
+    Show-LauncherError 'The Zephyr3D Editor dev launcher failed. Check the launcher log under %LOCALAPPDATA%\Zephyr3DEditor\dev-runtime.'
+    exit $process.ExitCode
+  }
+} catch {
+  Show-LauncherError ("Failed to launch the Zephyr3D Editor dev runtime.`n`n{0}" -f $_.Exception.Message)
+  exit 1
+}

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -27,6 +27,7 @@ import { FilePicker } from '../components/filepicker';
 import { fileListFileName, generateIndexTS, libDir } from './build/templates';
 import { DlgMessageBoxEx } from '../views/dlg/messageexdlg';
 import { DlgMessage } from '../views/dlg/messagedlg';
+import { DlgProgress } from '../views/dlg/progressdlg';
 import { EditorPluginManager, type EditorPlugin, type EditorPluginDefinition } from './plugin';
 import { ScriptRegistry } from '@zephyr3d/scene';
 import {
@@ -239,6 +240,51 @@ export class Editor {
   }
   private formatProjectLabel(project: ProjectInfo) {
     return project.path ? `${project.name} (${project.path})` : project.name;
+  }
+
+  private async runProjectOpenTask<T>(
+    title: string,
+    action: (updateProgress: (current: number, total: number, message: string) => void) => Promise<T>
+  ) {
+    const progress = new DlgProgress(`${title}##ProjectOpenProgress`, 420);
+    progress.showModal();
+    progress.setProgress(0, 5);
+    progress.setMessage('Preparing project...');
+    try {
+      const result = await action((current, total, message) => {
+        progress.setProgress(current, total);
+        progress.setMessage(message);
+      });
+      progress.setProgress(5, 5);
+      progress.setMessage('Project ready');
+      return result;
+    } finally {
+      progress.close();
+    }
+  }
+
+  private async ensureProjectDependenciesInstalled(
+    projectId: string,
+    settings: ProjectSettings,
+    onProgress?: (message: string) => void
+  ) {
+    const dependencyEntries = Object.entries(settings.dependencies ?? {});
+    if (dependencyEntries.length === 0) {
+      return;
+    }
+    let index = 0;
+    for (const [depName, depVersion] of dependencyEntries) {
+      index++;
+      const packageName = `${depName}@${depVersion}`;
+      const installed = await ProjectService.VFS.exists(`/${libDir}/deps/${packageName}`);
+      if (installed) {
+        continue;
+      }
+      onProgress?.(`Installing dependency ${packageName} (${index}/${dependencyEntries.length})...`);
+      await installDeps(projectId, ProjectService.VFS, '/', packageName, (message) => {
+        onProgress?.(`${message} (${index}/${dependencyEntries.length})`);
+      }, false);
+    }
   }
   async saveProject() {
     if (this._currentProject && !this._isRemoteProject) {
@@ -728,26 +774,30 @@ export class Editor {
     if (!url) {
       return;
     }
-    const fileList = await this.loadFileList(url);
-    if (!fileList) {
-      await DlgMessage.messageBox('Error', `Cannot read remote project at <${url}>`);
-      return;
-    }
-    const loading = new DlgMessageBoxEx('zephyr3d', 'Loading project, please wait...', []);
-    loading.showModal();
     try {
-      const project = await ProjectService.openRemoteProject(url, new RemoteProjectDirectoryReader(fileList));
-      this._currentProject = project;
-      this._isRemoteProject = true;
-      this._plugins.dispatchEvent('projectOpened', project);
-      this.loadDepTypes();
-      const settings = await ProjectService.getCurrentProjectSettings();
-      await this._moduleManager.activate(
-        'Scene',
-        settings.startupScene || this._currentProject.lastEditScene || ''
-      );
-    } finally {
-      loading.close('');
+      await this.runProjectOpenTask('Open Remote Project', async (updateProgress) => {
+        updateProgress(1, 5, 'Reading remote project file list...');
+        const fileList = await this.loadFileList(url as string);
+        if (!fileList) {
+          throw new Error(`Cannot read remote project at <${url}>`);
+        }
+        updateProgress(2, 5, 'Opening remote project...');
+        const project = await ProjectService.openRemoteProject(url as string, new RemoteProjectDirectoryReader(fileList));
+        this._currentProject = project;
+        this._isRemoteProject = true;
+        updateProgress(3, 5, 'Loading project settings...');
+        const settings = await ProjectService.getCurrentProjectSettings();
+        this._plugins.dispatchEvent('projectOpened', project);
+        updateProgress(4, 5, 'Loading script type hints...');
+        await this.loadDepTypes();
+        updateProgress(5, 5, 'Opening startup scene...');
+        await this._moduleManager.activate(
+          'Scene',
+          settings.startupScene || this._currentProject.lastEditScene || ''
+        );
+      });
+    } catch (err) {
+      await DlgMessage.messageBox('Error', `${err}`);
     }
   }
   async openProject(id?: string): Promise<{ id: Nullable<string>; err: Nullable<string> }> {
@@ -759,32 +809,23 @@ export class Editor {
         id = await Dialog.openFromList('Open Project', names, ids, 400, 400);
       }
       if (id) {
-        this._isRemoteProject = false;
-        const project = await ProjectService.openProject(id);
-        const settings = await ProjectService.getCurrentProjectSettings();
-        this._currentProject = project;
-        this._plugins.dispatchEvent('projectOpened', project);
-        this.loadDepTypes();
-        this._moduleManager.activate('Scene', settings.startupScene ?? project.lastEditScene ?? '');
-        for (const dep of Object.keys(settings.dependencies ?? {})) {
-          const depName = dep;
-          const depVersion = settings.dependencies[dep];
-          const packageName = `${depName}@${depVersion}`;
-          const installed = await ProjectService.VFS.exists(`/${libDir}/deps/${packageName}`);
-          if (!installed) {
-            const dlgMessageBoxEx = new DlgMessageBoxEx(
-              'Install package',
-              `Installing ${packageName}`,
-              [],
-              400,
-              0,
-              false
-            );
-            dlgMessageBoxEx.showModal();
-            await installDeps(id, ProjectService.VFS, '/', packageName, null, false);
-            dlgMessageBoxEx.close('');
-          }
-        }
+        await this.runProjectOpenTask('Open Project', async (updateProgress) => {
+          this._isRemoteProject = false;
+          updateProgress(1, 5, 'Opening project files...');
+          const project = await ProjectService.openProject(id as string);
+          this._currentProject = project;
+          updateProgress(2, 5, 'Loading project settings...');
+          const settings = await ProjectService.getCurrentProjectSettings();
+          this._plugins.dispatchEvent('projectOpened', project);
+          updateProgress(3, 5, 'Checking project dependencies...');
+          await this.ensureProjectDependenciesInstalled(id as string, settings, (message) => {
+            updateProgress(3, 5, message);
+          });
+          updateProgress(4, 5, 'Loading script type hints...');
+          await this.loadDepTypes();
+          updateProgress(5, 5, 'Opening startup scene...');
+          await this._moduleManager.activate('Scene', settings.startupScene ?? project.lastEditScene ?? '');
+        });
       }
       return {
         id,
@@ -925,33 +966,62 @@ export class Editor {
   }
 
   async refreshSystemPlugins() {
-    const refreshedLinkedPlugins = await SystemPluginService.refreshLinkedPlugins();
+    return this.refreshSystemPluginsWithProgress();
+  }
+
+  async refreshSystemPluginsWithProgress(onProgress?: (stage: string) => void) {
+    onProgress?.('正在刷新已 Link 的插件...');
+    const refreshedLinkedPlugins = await SystemPluginService.refreshLinkedPlugins(onProgress);
     for (const plugin of refreshedLinkedPlugins) {
       if (plugin.enabled) {
+        onProgress?.(`正在重新加载插件 ${plugin.name || plugin.id}...`);
         await this.tryLoadSystemPlugin(plugin.id, true);
       }
     }
+    onProgress?.('正在刷新插件列表...');
     return SystemPluginService.listPlugins();
   }
 
   async installSystemPluginFromFile(file: File) {
-    const plugin = await SystemPluginService.installPluginFromFile(file);
+    return this.installSystemPluginFromFileWithProgress(file);
+  }
+
+  async installSystemPluginFromFileWithProgress(file: File, onProgress?: (stage: string) => void) {
+    const plugin = await SystemPluginService.installPluginFromFile(file, onProgress);
+    onProgress?.(`正在加载插件 ${plugin.name || plugin.id}...`);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
     return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
   }
 
   async installSystemPluginFromDirectory(files: File[]) {
-    const plugin = await SystemPluginService.installPluginFromDirectory(files);
+    return this.installSystemPluginFromDirectoryWithProgress(files);
+  }
+
+  async installSystemPluginFromDirectoryWithProgress(files: File[], onProgress?: (stage: string) => void) {
+    const plugin = await SystemPluginService.installPluginFromDirectory(files, onProgress);
+    onProgress?.(`正在加载插件 ${plugin.name || plugin.id}...`);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
     return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
   }
 
   async linkSystemPlugin(directory: string, entryFileName?: string) {
-    const plugin = await SystemPluginService.linkPlugin({
-      directory,
-      entryFileName,
-      enabled: true
-    });
+    return this.linkSystemPluginWithProgress(directory, entryFileName);
+  }
+
+  async linkSystemPluginWithProgress(
+    directory: string,
+    entryFileName?: string,
+    onProgress?: (stage: string) => void
+  ) {
+    const plugin = await SystemPluginService.linkPlugin(
+      {
+        directory,
+        entryFileName,
+        enabled: true
+      },
+      onProgress
+    );
+    onProgress?.(`正在加载插件 ${plugin.name || plugin.id}...`);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
     return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
   }

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -909,6 +909,16 @@ export class Editor {
     return SystemPluginService.listPlugins();
   }
 
+  async refreshSystemPlugins() {
+    const refreshedLinkedPlugins = await SystemPluginService.refreshLinkedPlugins();
+    for (const plugin of refreshedLinkedPlugins) {
+      if (plugin.enabled) {
+        await this.tryLoadSystemPlugin(plugin.id, true);
+      }
+    }
+    return SystemPluginService.listPlugins();
+  }
+
   async installSystemPluginFromFile(file: File) {
     const plugin = await SystemPluginService.installPluginFromFile(file);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
@@ -919,6 +929,20 @@ export class Editor {
     const plugin = await SystemPluginService.installPluginFromDirectory(files);
     const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
     return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
+  }
+
+  async linkSystemPlugin(directory: string, entryFileName?: string) {
+    const plugin = await SystemPluginService.linkPlugin({
+      directory,
+      entryFileName,
+      enabled: true
+    });
+    const loadedId = await this.tryLoadSystemPlugin(plugin.id, true);
+    return (await SystemPluginService.getPlugin(loadedId ?? plugin.id)) ?? plugin;
+  }
+
+  async unlinkSystemPlugin(id: string) {
+    await this.removeSystemPlugin(id);
   }
 
   async installSystemPluginFiles(input: {

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -287,6 +287,17 @@ export class Editor {
     }
     await ProjectService.VFS.writeFile(path, content, { encoding: 'utf8', create: true });
   }
+  async deleteProjectFile(path: string) {
+    if (!this._currentProject) {
+      throw new Error('No project is currently open');
+    }
+    if (ProjectService.VFS.readOnly) {
+      throw new Error('Current project is read-only');
+    }
+    if (await ProjectService.VFS.exists(path)) {
+      await ProjectService.VFS.deleteFile(path);
+    }
+  }
   async openProjectCodeFile(path: string, language?: string) {
     if (!this._currentProject) {
       throw new Error('No project is currently open');
@@ -641,6 +652,7 @@ export class Editor {
         const project = await ProjectService.openProject(uuid);
         const settings = await ProjectService.getCurrentProjectSettings();
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         let scene = settings.startupScene ?? project.lastEditScene ?? '';
         if (!scene) {
           const sceneFiles = await ProjectService.VFS.glob('/**/*.zscn', {
@@ -699,6 +711,7 @@ export class Editor {
         }
         const project = await ProjectService.openProject(uuid);
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         this._moduleManager.activate('Scene', '');
         return this._currentProject.uuid;
       } catch (err) {
@@ -726,6 +739,7 @@ export class Editor {
       const project = await ProjectService.openRemoteProject(url, new RemoteProjectDirectoryReader(fileList));
       this._currentProject = project;
       this._isRemoteProject = true;
+      this._plugins.dispatchEvent('projectOpened', project);
       this.loadDepTypes();
       const settings = await ProjectService.getCurrentProjectSettings();
       await this._moduleManager.activate(
@@ -749,6 +763,7 @@ export class Editor {
         const project = await ProjectService.openProject(id);
         const settings = await ProjectService.getCurrentProjectSettings();
         this._currentProject = project;
+        this._plugins.dispatchEvent('projectOpened', project);
         this.loadDepTypes();
         this._moduleManager.activate('Scene', settings.startupScene ?? project.lastEditScene ?? '');
         for (const dep of Object.keys(settings.dependencies ?? {})) {

--- a/utility/editor/src/core/pluginapi.ts
+++ b/utility/editor/src/core/pluginapi.ts
@@ -156,6 +156,7 @@ export type EditorEditToolFactoryContext = {
 };
 
 export type EditorEventMap = {
+  projectOpened: [project: EditorProjectInfo];
   sceneOpening: [path: string];
   sceneOpened: [scene: unknown, path: string];
   sceneCreated: [scene: unknown, path: string];

--- a/utility/editor/src/core/services/storage.ts
+++ b/utility/editor/src/core/services/storage.ts
@@ -18,6 +18,13 @@ export function createProjectVFS(uuid: string): VFS {
   return getDesktopAPI() ? createElectronProjectFS(uuid) : new IndexedDBFS(uuid, STORE_NAME);
 }
 
+export function createLinkedDirectoryVFS(directory: string): VFS {
+  if (!getDesktopAPI()) {
+    throw new Error('Linked plugins are only supported in the desktop editor');
+  }
+  return createElectronProjectFS(directory);
+}
+
 export async function deleteProjectVFS(uuid: string) {
   if (getDesktopAPI()) {
     await createElectronProjectFS(uuid).deleteFileSystem();

--- a/utility/editor/src/core/services/systemplugin.ts
+++ b/utility/editor/src/core/services/systemplugin.ts
@@ -2,7 +2,7 @@ import { PathUtils } from '@zephyr3d/base';
 import { BlobReader, TextWriter, ZipReader, configure, type FileEntry } from '@zip.js/zip.js';
 import { libDir } from '../build/templates';
 import { installDeps } from '../build/dep';
-import { createSystemPluginVFS } from './storage';
+import { createLinkedDirectoryVFS, createSystemPluginVFS } from './storage';
 
 configure({ useWebWorkers: false });
 
@@ -21,6 +21,9 @@ export type SystemPluginManifestEntry = {
   description?: string;
   entry: string;
   dependencies?: Record<string, string>;
+  linked?: {
+    directory: string;
+  };
   enabled: boolean;
   installedAt: number;
   updatedAt: number;
@@ -81,6 +84,12 @@ export type InstallSystemPluginFilesInput = {
   enabled?: boolean;
 };
 
+export type LinkSystemPluginInput = {
+  directory: string;
+  entryFileName?: string;
+  enabled?: boolean;
+};
+
 export type SystemPluginFileRecord = {
   path: string;
   relativePath: string;
@@ -95,6 +104,9 @@ export type SystemPluginDirectoryRecord = {
 };
 
 export class SystemPluginService {
+  private static readonly _linkedPluginMounts = new Map<string, ReturnType<typeof createLinkedDirectoryVFS>>();
+  private static readonly _linkedPluginDirectories = new Map<string, string>();
+
   static get VFS() {
     return systemPluginVFS;
   }
@@ -121,16 +133,19 @@ export class SystemPluginService {
   }
 
   static async listPlugins(): Promise<SystemPluginRecord[]> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     return Object.values(manifest.plugins).map((plugin) => this.toRecord(plugin));
   }
 
   static async getPlugin(id: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     return manifest.plugins[id] ? this.toRecord(manifest.plugins[id]) : null;
   }
 
   static async getInstalledPluginSource(id: string): Promise<InstalledSystemPlugin | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     const plugin = manifest.plugins[id];
     if (!plugin) {
@@ -205,6 +220,7 @@ export class SystemPluginService {
   }
 
   static async findPluginByPath(path: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     const plugins = await this.listPlugins();
     for (const plugin of plugins) {
@@ -221,6 +237,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
@@ -254,6 +273,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin directory path must not be empty');
@@ -279,6 +301,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
     const oldPath = this.normalizePluginFilePath(oldRelativePath);
     const nextPath = this.normalizePluginFilePath(newRelativePath);
@@ -320,6 +345,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin file path must not be empty');
@@ -355,6 +383,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const oldPath = this.normalizePluginFilePath(oldRelativePath);
     const nextPath = this.normalizePluginFilePath(newRelativePath);
     if (!oldPath || !nextPath) {
@@ -388,6 +419,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
+    }
     const normalizedRelativePath = this.normalizePluginFilePath(relativePath);
     if (!normalizedRelativePath) {
       throw new Error('Plugin directory path must not be empty');
@@ -411,6 +445,7 @@ export class SystemPluginService {
   }
 
   static async getPluginByPath(path: string): Promise<SystemPluginRecord | null> {
+    await this.syncLinkedPluginMounts();
     const manifest = await this.readManifest();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     for (const plugin of Object.values(manifest.plugins)) {
@@ -455,6 +490,8 @@ export class SystemPluginService {
     const oldEntry = manifest.plugins[packageManifest.id];
     const packageDir = this.getPackageDir(packageManifest.id);
 
+    await this.unmountLinkedPlugin(packageManifest.id);
+
     await systemPluginVFS.deleteDirectory(packageDir, true).catch(() => undefined);
     await systemPluginVFS.makeDirectory(packageDir, true);
     for (const file of normalizedFiles) {
@@ -478,6 +515,7 @@ export class SystemPluginService {
       dependencies: packageManifest.dependencies
         ? { ...packageManifest.dependencies }
         : oldEntry?.dependencies,
+      linked: undefined,
       enabled: input.enabled ?? true,
       installedAt: oldEntry?.installedAt ?? now,
       updatedAt: now
@@ -486,12 +524,78 @@ export class SystemPluginService {
     return this.toRecord(manifest.plugins[packageManifest.id]);
   }
 
+  static async linkPlugin(input: LinkSystemPluginInput): Promise<SystemPluginRecord> {
+    await this.ensureLayout();
+    const linkedInfo = await this.readLinkedPluginInput(input.directory, input.entryFileName);
+    const packageManifest = linkedInfo.packageManifest;
+    const entryFileName = linkedInfo.entryFileName;
+
+    const now = Date.now();
+    const manifest = await this.readManifest();
+    const oldEntry = manifest.plugins[packageManifest.id];
+    manifest.plugins[packageManifest.id] = {
+      id: packageManifest.id,
+      name: packageManifest.name,
+      version: packageManifest.version,
+      description: packageManifest.description,
+      entry: `/${entryFileName}`,
+      dependencies: packageManifest.dependencies,
+      linked: {
+        directory: input.directory
+      },
+      enabled: input.enabled ?? true,
+      installedAt: oldEntry?.installedAt ?? now,
+      updatedAt: now
+    };
+    await this.writeManifest(manifest);
+    await this.mountLinkedPlugin(this.toRecord(manifest.plugins[packageManifest.id]));
+    return this.toRecord(manifest.plugins[packageManifest.id]);
+  }
+
+  static async refreshLinkedPlugins(): Promise<SystemPluginRecord[]> {
+    await this.ensureLayout();
+    const manifest = await this.readManifest();
+    const refreshed: SystemPluginRecord[] = [];
+    let dirty = false;
+    for (const plugin of Object.values(manifest.plugins)) {
+      const directory = plugin.linked?.directory?.trim();
+      if (!directory) {
+        continue;
+      }
+      const linkedInfo = await this.readLinkedPluginInput(directory, plugin.entry.replace(/^\/+/, ''));
+      const nextManifest = linkedInfo.packageManifest;
+      const nextEntry = linkedInfo.entryFileName;
+      if (
+        plugin.name !== nextManifest.name ||
+        plugin.version !== nextManifest.version ||
+        plugin.description !== nextManifest.description ||
+        plugin.entry !== `/${nextEntry}` ||
+        JSON.stringify(plugin.dependencies ?? {}) !== JSON.stringify(nextManifest.dependencies ?? {})
+      ) {
+        plugin.name = nextManifest.name;
+        plugin.version = nextManifest.version;
+        plugin.description = nextManifest.description;
+        plugin.entry = `/${nextEntry}`;
+        plugin.dependencies = nextManifest.dependencies;
+        plugin.updatedAt = Date.now();
+        dirty = true;
+      }
+      refreshed.push(this.toRecord(plugin));
+    }
+    if (dirty) {
+      await this.writeManifest(manifest);
+    }
+    await this.syncLinkedPluginMounts();
+    return refreshed;
+  }
+
   static async removePlugin(id: string): Promise<void> {
     const manifest = await this.readManifest();
     const plugin = manifest.plugins[id];
     if (!plugin) {
       return;
     }
+    await this.unmountLinkedPlugin(id);
     delete manifest.plugins[id];
     await this.writeManifest(manifest);
     await systemPluginVFS.deleteDirectory(this.getPackageDir(id), true).catch(() => undefined);
@@ -636,6 +740,9 @@ export class SystemPluginService {
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
     }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' cannot install dependencies from the built-in plugin manager`);
+    }
     const match = spec.match(/^((?:@[^/]+\/)?[^@/]+)(?:@(.+))?$/);
     const packageName = match?.[1] ?? spec;
     const previousVersion = plugin.dependencies?.[packageName];
@@ -663,6 +770,9 @@ export class SystemPluginService {
     const plugin = await this.getPlugin(pluginId);
     if (!plugin) {
       throw new Error(`System plugin '${pluginId}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' cannot remove dependencies from the built-in plugin manager`);
     }
     const manifest = await this.readManifest();
     const manifestEntry = manifest.plugins[pluginId];
@@ -722,10 +832,14 @@ export class SystemPluginService {
 
   static async updatePluginFile(path: string, source: string): Promise<SystemPluginRecord> {
     await this.ensureLayout();
+    await this.syncLinkedPluginMounts();
     const normalizedPath = systemPluginVFS.normalizePath(path);
     const plugin = await this.getPluginByPath(normalizedPath);
     if (!plugin) {
       throw new Error(`System plugin file '${path}' is not installed`);
+    }
+    if (plugin.linked?.directory) {
+      throw new Error(`Linked plugin '${plugin.id}' is read-only in the built-in plugin editor`);
     }
 
     const manifest = await this.readManifest();
@@ -1124,6 +1238,10 @@ export class SystemPluginService {
         delete plugin.builtin;
         dirty = true;
       }
+      if (plugin.linked && typeof plugin.linked.directory !== 'string') {
+        delete plugin.linked;
+        dirty = true;
+      }
     }
     if (dirty) {
       await this.writeManifest(normalized);
@@ -1147,6 +1265,74 @@ export class SystemPluginService {
       settingsPath: this.getSettingsPath(plugin.id),
       depsRoot: this.getDependenciesRoot(plugin.id),
       depsLockPath: this.getDependenciesLockPath(plugin.id)
+    };
+  }
+
+  private static async syncLinkedPluginMounts() {
+    const manifest = await this.readManifest();
+    const linkedEntries = Object.values(manifest.plugins).filter((plugin) => !!plugin.linked?.directory);
+    const keepIds = new Set(linkedEntries.map((plugin) => plugin.id));
+    for (const id of [...this._linkedPluginMounts.keys()]) {
+      if (!keepIds.has(id)) {
+        await this.unmountLinkedPlugin(id);
+      }
+    }
+    for (const entry of linkedEntries) {
+      await this.mountLinkedPlugin(this.toRecord(entry));
+    }
+  }
+
+  private static async mountLinkedPlugin(plugin: SystemPluginRecord) {
+    const directory = plugin.linked?.directory?.trim();
+    if (!directory) {
+      await this.unmountLinkedPlugin(plugin.id);
+      return;
+    }
+    const currentDirectory = this._linkedPluginDirectories.get(plugin.id);
+    if (currentDirectory === directory && this._linkedPluginMounts.has(plugin.id)) {
+      return;
+    }
+    await this.unmountLinkedPlugin(plugin.id);
+    const vfs = createLinkedDirectoryVFS(directory);
+    await systemPluginVFS.mount(this.getPackageDir(plugin.id), vfs);
+    this._linkedPluginMounts.set(plugin.id, vfs);
+    this._linkedPluginDirectories.set(plugin.id, directory);
+  }
+
+  private static async unmountLinkedPlugin(id: string) {
+    if (this._linkedPluginMounts.has(id)) {
+      await systemPluginVFS.unmount(this.getPackageDir(id)).catch(() => false);
+      const vfs = this._linkedPluginMounts.get(id);
+      this._linkedPluginMounts.delete(id);
+      this._linkedPluginDirectories.delete(id);
+      await vfs?.close?.();
+    }
+  }
+
+  private static async readLinkedPluginInput(directory: string, entryFileName?: string) {
+    const linkedVFS = createLinkedDirectoryVFS(directory);
+    const files = await linkedVFS.readDirectory('/', {
+      includeHidden: true,
+      recursive: true
+    });
+    const inputFiles: SystemPluginFileInput[] = [];
+    for (const item of files) {
+      if (item.type !== 'file') {
+        continue;
+      }
+      inputFiles.push({
+        path: linkedVFS.relative(item.path, '/'),
+        source: (await linkedVFS.readFile(item.path, { encoding: 'utf8' })) as string
+      });
+    }
+    const packageFiles = this.normalizeImportedPluginFiles(inputFiles);
+    const packageManifest = this.readPackageManifestFromFiles(packageFiles);
+    const normalizedEntryFileName = this.normalizeEntryFileName(entryFileName ?? packageManifest.entry);
+    this.validatePluginFiles(packageFiles, normalizedEntryFileName, packageManifest.id);
+    await linkedVFS.close();
+    return {
+      packageManifest,
+      entryFileName: normalizedEntryFileName
     };
   }
 }

--- a/utility/editor/src/core/services/systemplugin.ts
+++ b/utility/editor/src/core/services/systemplugin.ts
@@ -92,6 +92,8 @@ export type LinkSystemPluginInput = {
   enabled?: boolean;
 };
 
+export type SystemPluginProgressHandler = (stage: string) => void;
+
 export type SystemPluginFileRecord = {
   path: string;
   relativePath: string;
@@ -508,7 +510,11 @@ export class SystemPluginService {
     });
   }
 
-  static async installPluginFiles(input: InstallSystemPluginFilesInput): Promise<SystemPluginRecord> {
+  static async installPluginFiles(
+    input: InstallSystemPluginFilesInput,
+    onProgress?: SystemPluginProgressHandler
+  ): Promise<SystemPluginRecord> {
+    onProgress?.('正在校验插件清单...');
     await this.ensureLayout();
     const packageManifest = this.resolvePackageManifestForInstall(input);
     const normalizedFiles = this.withPackageManifestFile(
@@ -523,10 +529,12 @@ export class SystemPluginService {
     const oldEntry = manifest.plugins[packageManifest.id];
     const packageDir = this.getPackageDir(packageManifest.id);
 
+    onProgress?.('正在清理旧插件文件...');
     await this.unmountLinkedPlugin(packageManifest.id);
 
     await systemPluginVFS.deleteDirectory(packageDir, true).catch(() => undefined);
     await systemPluginVFS.makeDirectory(packageDir, true);
+    onProgress?.('正在写入插件文件...');
     for (const file of normalizedFiles) {
       const fullPath = systemPluginVFS.join(packageDir, file.path);
       await this.ensureParentDirectory(fullPath);
@@ -539,6 +547,7 @@ export class SystemPluginService {
       await systemPluginVFS.makeDirectory(systemPluginVFS.join(packageDir, libDir), true);
     }
 
+    onProgress?.('正在更新插件清单...');
     manifest.plugins[packageManifest.id] = {
       id: packageManifest.id,
       name: packageManifest.name,
@@ -557,9 +566,13 @@ export class SystemPluginService {
     return this.toRecord(manifest.plugins[packageManifest.id]);
   }
 
-  static async linkPlugin(input: LinkSystemPluginInput): Promise<SystemPluginRecord> {
+  static async linkPlugin(
+    input: LinkSystemPluginInput,
+    onProgress?: SystemPluginProgressHandler
+  ): Promise<SystemPluginRecord> {
+    onProgress?.('正在读取插件源码...');
     await this.ensureLayout();
-    const linkedInfo = await this.readLinkedPluginInput(input.directory, input.entryFileName);
+    const linkedInfo = await this.readLinkedPluginInput(input.directory, input.entryFileName, onProgress);
     const packageManifest = linkedInfo.packageManifest;
     const entryFileName = linkedInfo.entryFileName;
 
@@ -584,22 +597,32 @@ export class SystemPluginService {
       installedAt: oldEntry?.installedAt ?? now,
       updatedAt: now
     };
+    onProgress?.('正在写入 Link 信息...');
     await this.writeManifest(manifest);
+    onProgress?.('正在挂载插件目录...');
     await this.mountLinkedPlugin(this.toRecord(manifest.plugins[packageManifest.id]));
     return this.toRecord(manifest.plugins[packageManifest.id]);
   }
 
-  static async refreshLinkedPlugins(): Promise<SystemPluginRecord[]> {
+  static async refreshLinkedPlugins(onProgress?: SystemPluginProgressHandler): Promise<SystemPluginRecord[]> {
     await this.ensureLayout();
     const manifest = await this.readManifest();
+    const linkedEntries = Object.values(manifest.plugins).filter((plugin) => !!plugin.linked?.directory);
     const refreshed: SystemPluginRecord[] = [];
     let dirty = false;
+    let index = 0;
     for (const plugin of Object.values(manifest.plugins)) {
       const directory = plugin.linked?.directory?.trim();
       if (!directory) {
         continue;
       }
-      const linkedInfo = await this.readLinkedPluginInput(directory, plugin.linked?.entry?.replace(/^\/+/, ''));
+      index++;
+      onProgress?.(`正在刷新插件 ${plugin.name || plugin.id} (${index}/${linkedEntries.length})...`);
+      const linkedInfo = await this.readLinkedPluginInput(
+        directory,
+        plugin.linked?.entry?.replace(/^\/+/, ''),
+        onProgress
+      );
       const nextManifest = linkedInfo.packageManifest;
       const nextEntry = linkedInfo.entryFileName;
       if (
@@ -620,8 +643,10 @@ export class SystemPluginService {
       refreshed.push(this.toRecord(plugin));
     }
     if (dirty) {
+      onProgress?.('正在写回刷新后的插件清单...');
       await this.writeManifest(manifest);
     }
+    onProgress?.('正在同步已 Link 的插件目录...');
     await this.syncLinkedPluginMounts();
     return refreshed;
   }
@@ -706,23 +731,31 @@ export class SystemPluginService {
     )}\n`;
   }
 
-  static async installPluginFromFile(file: File): Promise<SystemPluginRecord> {
+  static async installPluginFromFile(
+    file: File,
+    onProgress?: SystemPluginProgressHandler
+  ): Promise<SystemPluginRecord> {
     const fileName = (file.name || '').toLowerCase();
     if (!fileName.endsWith('.zip')) {
       throw new Error(
         "Install Plugin only accepts '.zip' plugin packages. Use Install Folder for unpacked plugins."
       );
     }
-    return this.installPluginFromZip(file);
+    return this.installPluginFromZip(file, onProgress);
   }
 
-  static async installPluginFromDirectory(files: File[]): Promise<SystemPluginRecord> {
+  static async installPluginFromDirectory(
+    files: File[],
+    onProgress?: SystemPluginProgressHandler
+  ): Promise<SystemPluginRecord> {
+    onProgress?.('正在读取插件目录文件...');
     const inputFiles = await Promise.all(
       files.map(async (file) => ({
         path: this.normalizePluginFilePath(file.webkitRelativePath || file.name),
         source: await file.text()
       }))
     );
+    onProgress?.('正在解析插件目录结构...');
     const packageFiles = this.normalizeImportedPluginFiles(inputFiles);
     const packageManifest = this.readPackageManifestFromFiles(packageFiles);
     return this.installPluginFiles({
@@ -734,14 +767,19 @@ export class SystemPluginService {
       dependencies: packageManifest.dependencies,
       files: packageFiles,
       enabled: true
-    });
+    }, onProgress);
   }
 
-  static async installPluginFromZip(file: Blob): Promise<SystemPluginRecord> {
+  static async installPluginFromZip(
+    file: Blob,
+    onProgress?: SystemPluginProgressHandler
+  ): Promise<SystemPluginRecord> {
+    onProgress?.('正在读取 ZIP 插件包...');
     const zipReader = new ZipReader(new BlobReader(file));
     try {
       const entries = await zipReader.getEntries();
       const inputFiles: SystemPluginFileInput[] = [];
+      onProgress?.(`正在解压插件文件（共 ${entries.filter((entry) => !entry.directory).length} 个）...`);
       for (const entry of entries) {
         if (entry.directory) {
           continue;
@@ -751,6 +789,7 @@ export class SystemPluginService {
           source: await (entry as FileEntry).getData(new TextWriter())
         });
       }
+      onProgress?.('正在解析插件包结构...');
       const packageFiles = this.normalizeImportedPluginFiles(inputFiles);
       const packageManifest = this.readPackageManifestFromFiles(packageFiles);
       return this.installPluginFiles({
@@ -762,7 +801,7 @@ export class SystemPluginService {
         dependencies: packageManifest.dependencies,
         files: packageFiles,
         enabled: true
-      });
+      }, onProgress);
     } finally {
       await zipReader.close();
     }
@@ -1614,14 +1653,20 @@ export class SystemPluginService {
     }
   }
 
-  private static async readLinkedPluginInput(directory: string, entryFileName?: string) {
+  private static async readLinkedPluginInput(
+    directory: string,
+    entryFileName?: string,
+    onProgress?: SystemPluginProgressHandler
+  ) {
     const linkedVFS = createLinkedDirectoryVFS(directory);
     try {
+      onProgress?.('正在读取插件清单...');
       const { manifestFileName, manifestSource, packageManifest } = await this.readLinkedPackageManifest(
         directory,
         linkedVFS
       );
       const normalizedEntryFileName = this.normalizeEntryFileName(entryFileName ?? packageManifest.entry);
+      onProgress?.('正在分析插件入口依赖...');
       const graphFilesResult = await this.collectLinkedPluginGraphFiles(directory, linkedVFS, normalizedEntryFileName);
       const graphFiles = graphFilesResult.files;
       const packageFiles =
@@ -1632,12 +1677,14 @@ export class SystemPluginService {
         manifestFileName === SYSTEM_PLUGIN_PACKAGE_MANIFEST
           ? packageFiles
           : this.withPackageManifestFile(packageFiles, packageManifest);
+      onProgress?.('正在校验插件源码...');
       this.validatePluginFiles(
         validationFiles,
         normalizedEntryFileName,
         packageManifest.id,
         graphFilesResult.importSpecifiersByPath
       );
+      onProgress?.('正在检查插件依赖缓存...');
       await this.ensureLinkedPluginDependencies(linkedVFS, packageManifest);
       return {
         packageManifest,

--- a/utility/editor/src/core/services/systemplugin.ts
+++ b/utility/editor/src/core/services/systemplugin.ts
@@ -1,7 +1,7 @@
 import { PathUtils } from '@zephyr3d/base';
 import { BlobReader, TextWriter, ZipReader, configure, type FileEntry } from '@zip.js/zip.js';
 import { libDir } from '../build/templates';
-import { installDeps } from '../build/dep';
+import { installDeps, readLock } from '../build/dep';
 import { createLinkedDirectoryVFS, createSystemPluginVFS } from './storage';
 
 configure({ useWebWorkers: false });
@@ -13,6 +13,7 @@ const SYSTEM_PLUGIN_PACKAGES_DIR = `${SYSTEM_PLUGIN_ROOT}/packages`;
 const SYSTEM_PLUGIN_STATE_DIR = `${SYSTEM_PLUGIN_ROOT}/state`;
 const SYSTEM_PLUGIN_MANIFEST = `${SYSTEM_PLUGIN_ROOT}/manifest.json`;
 const SYSTEM_PLUGIN_PACKAGE_MANIFEST = 'plugin.json';
+const SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST = 'plugin.dev.json';
 
 export type SystemPluginManifestEntry = {
   id: string;
@@ -23,6 +24,7 @@ export type SystemPluginManifestEntry = {
   dependencies?: Record<string, string>;
   linked?: {
     directory: string;
+    entry?: string;
   };
   enabled: boolean;
   installedAt: number;
@@ -103,9 +105,40 @@ export type SystemPluginDirectoryRecord = {
   name: string;
 };
 
+type LinkedPluginFileAnalysisCacheEntry = {
+  source: string;
+  importSpecifiers: string[];
+  modifiedAt: number;
+  size: number;
+};
+
+type LinkedPluginEntryGraphCacheEntry = {
+  filePaths: string[];
+};
+
+type LinkedPluginManifestCacheEntry = {
+  manifestFileName: string;
+  manifestSource: string;
+  packageManifest: SystemPluginPackageManifest;
+  modifiedAt: number;
+  size: number;
+};
+
+type LinkedPluginGraphFilesResult = {
+  files: SystemPluginFileInput[];
+  importSpecifiersByPath: Map<string, string[]>;
+};
+
+type LinkedPluginGraphCache = {
+  manifest?: LinkedPluginManifestCacheEntry;
+  files: Map<string, LinkedPluginFileAnalysisCacheEntry>;
+  entryGraphs: Map<string, LinkedPluginEntryGraphCacheEntry>;
+};
+
 export class SystemPluginService {
   private static readonly _linkedPluginMounts = new Map<string, ReturnType<typeof createLinkedDirectoryVFS>>();
   private static readonly _linkedPluginDirectories = new Map<string, string>();
+  private static readonly _linkedPluginGraphCaches = new Map<string, LinkedPluginGraphCache>();
 
   static get VFS() {
     return systemPluginVFS;
@@ -533,6 +566,9 @@ export class SystemPluginService {
     const now = Date.now();
     const manifest = await this.readManifest();
     const oldEntry = manifest.plugins[packageManifest.id];
+    if (oldEntry?.linked?.directory && oldEntry.linked.directory !== input.directory) {
+      this._linkedPluginGraphCaches.delete(oldEntry.linked.directory);
+    }
     manifest.plugins[packageManifest.id] = {
       id: packageManifest.id,
       name: packageManifest.name,
@@ -541,7 +577,8 @@ export class SystemPluginService {
       entry: `/${entryFileName}`,
       dependencies: packageManifest.dependencies,
       linked: {
-        directory: input.directory
+        directory: input.directory,
+        entry: input.entryFileName ? `/${entryFileName}` : undefined
       },
       enabled: input.enabled ?? true,
       installedAt: oldEntry?.installedAt ?? now,
@@ -562,7 +599,7 @@ export class SystemPluginService {
       if (!directory) {
         continue;
       }
-      const linkedInfo = await this.readLinkedPluginInput(directory, plugin.entry.replace(/^\/+/, ''));
+      const linkedInfo = await this.readLinkedPluginInput(directory, plugin.linked?.entry?.replace(/^\/+/, ''));
       const nextManifest = linkedInfo.packageManifest;
       const nextEntry = linkedInfo.entryFileName;
       if (
@@ -881,7 +918,12 @@ export class SystemPluginService {
     this.validatePluginImports(source);
   }
 
-  static validatePluginFiles(files: SystemPluginFileInput[], entryFileName: string, pluginId?: string) {
+  static validatePluginFiles(
+    files: SystemPluginFileInput[],
+    entryFileName: string,
+    pluginId?: string,
+    importSpecifiersByPath?: ReadonlyMap<string, string[]>
+  ) {
     const normalizedFiles = this.normalizePluginFiles(files);
     const entryPath = this.normalizePluginFilePath(entryFileName);
     const packageManifest = this.readPackageManifestFromFiles(normalizedFiles);
@@ -902,14 +944,15 @@ export class SystemPluginService {
       if (file.path === SYSTEM_PLUGIN_PACKAGE_MANIFEST) {
         continue;
       }
-      this.validatePluginImports(file.source);
-      this.validateRelativeImportsStayWithinPlugin(file.path, file.source);
+      const specs = importSpecifiersByPath?.get(file.path);
+      this.validatePluginImports(file.source, specs);
+      this.validateRelativeImportsStayWithinPlugin(file.path, file.source, specs);
     }
   }
 
-  private static validatePluginImports(source: string) {
-    const specs = this.collectImportSpecifiers(source);
-    for (const spec of specs) {
+  private static validatePluginImports(source: string, specs?: readonly string[]) {
+    const importSpecs = specs ?? this.collectImportSpecifiers(source);
+    for (const spec of importSpecs) {
       if (spec.startsWith('./') || spec.startsWith('../') || spec.startsWith('/')) {
         continue;
       }
@@ -969,6 +1012,197 @@ export class SystemPluginService {
     return resolved.join('/');
   }
 
+  private static stripPluginImportQuery(spec: string) {
+    const queryIndex = spec.indexOf('?');
+    const hashIndex = spec.indexOf('#');
+    const cutIndex =
+      queryIndex >= 0 && hashIndex >= 0
+        ? Math.min(queryIndex, hashIndex)
+        : queryIndex >= 0
+          ? queryIndex
+          : hashIndex;
+    return cutIndex >= 0 ? spec.slice(0, cutIndex) : spec;
+  }
+
+  private static async resolveLinkedPluginModulePath(
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>,
+    path: string
+  ): Promise<string | null> {
+    const candidates = new Set<string>();
+    const normalizedPath = this.normalizePluginFilePath(path);
+    if (normalizedPath) {
+      candidates.add(normalizedPath);
+      if (!/\.(ts|js|mjs)$/i.test(normalizedPath)) {
+        candidates.add(`${normalizedPath}.ts`);
+        candidates.add(`${normalizedPath}.js`);
+        candidates.add(`${normalizedPath}.mjs`);
+      }
+    }
+    for (const candidate of candidates) {
+      const absolutePath = linkedVFS.normalizePath(linkedVFS.join('/', candidate));
+      if (!(await linkedVFS.exists(absolutePath))) {
+        continue;
+      }
+      const stat = await linkedVFS.stat(absolutePath);
+      if (stat.isFile) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private static getLinkedPluginGraphCache(directory: string): LinkedPluginGraphCache {
+    let cache = this._linkedPluginGraphCaches.get(directory);
+    if (!cache) {
+      cache = {
+        files: new Map(),
+        entryGraphs: new Map()
+      };
+      this._linkedPluginGraphCaches.set(directory, cache);
+    }
+    return cache;
+  }
+
+  private static getLinkedPluginFileCacheFingerprint(stat: { modified: Date; size: number }) {
+    return {
+      modifiedAt: stat.modified?.getTime?.() ?? 0,
+      size: stat.size ?? 0
+    };
+  }
+
+  private static isLinkedPluginFileCacheCurrent(
+    cacheEntry: { modifiedAt: number; size: number } | undefined,
+    stat: { modified: Date; size: number }
+  ) {
+    if (!cacheEntry) {
+      return false;
+    }
+    const fingerprint = this.getLinkedPluginFileCacheFingerprint(stat);
+    return cacheEntry.modifiedAt === fingerprint.modifiedAt && cacheEntry.size === fingerprint.size;
+  }
+
+  private static async getLinkedPluginFileAnalysis(
+    cache: LinkedPluginGraphCache,
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>,
+    normalizedPath: string
+  ) {
+    const absolutePath = linkedVFS.normalizePath(linkedVFS.join('/', normalizedPath));
+    const stat = await linkedVFS.stat(absolutePath);
+    if (!stat.isFile) {
+      throw new Error(`Plugin file '${normalizedPath}' does not exist`);
+    }
+    const cached = cache.files.get(normalizedPath);
+    if (this.isLinkedPluginFileCacheCurrent(cached, stat)) {
+      return cached;
+    }
+    const source = (await linkedVFS.readFile(absolutePath, { encoding: 'utf8' })) as string;
+    const fingerprint = this.getLinkedPluginFileCacheFingerprint(stat);
+    const analysis: LinkedPluginFileAnalysisCacheEntry = {
+      source,
+      importSpecifiers: this.collectImportSpecifiers(source),
+      modifiedAt: fingerprint.modifiedAt,
+      size: fingerprint.size
+    };
+    cache.files.set(normalizedPath, analysis);
+    return analysis;
+  }
+
+  private static async tryCollectCachedLinkedPluginGraphFiles(
+    cache: LinkedPluginGraphCache,
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>,
+    resolvedEntryPath: string
+  ): Promise<LinkedPluginGraphFilesResult | null> {
+    const entryCache = cache.entryGraphs.get(resolvedEntryPath);
+    if (!entryCache || entryCache.filePaths.length === 0) {
+      return null;
+    }
+    const files: SystemPluginFileInput[] = [];
+    const importSpecifiersByPath = new Map<string, string[]>();
+    for (const filePath of entryCache.filePaths) {
+      const absolutePath = linkedVFS.normalizePath(linkedVFS.join('/', filePath));
+      if (!(await linkedVFS.exists(absolutePath))) {
+        return null;
+      }
+      const stat = await linkedVFS.stat(absolutePath);
+      if (!stat.isFile) {
+        return null;
+      }
+      const cached = cache.files.get(filePath);
+      if (!this.isLinkedPluginFileCacheCurrent(cached, stat) || !cached) {
+        return null;
+      }
+      files.push({
+        path: filePath,
+        source: cached.source
+      });
+      importSpecifiersByPath.set(filePath, cached.importSpecifiers);
+    }
+    return {
+      files,
+      importSpecifiersByPath
+    };
+  }
+
+  private static async collectLinkedPluginGraphFiles(
+    directory: string,
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>,
+    entryFileName: string
+  ): Promise<LinkedPluginGraphFilesResult> {
+    const resolvedEntryPath = await this.resolveLinkedPluginModulePath(linkedVFS, entryFileName);
+    if (!resolvedEntryPath) {
+      throw new Error(`System plugin entry '${entryFileName}' does not exist in linked plugin`);
+    }
+
+    const cache = this.getLinkedPluginGraphCache(directory);
+    const cachedGraph = await this.tryCollectCachedLinkedPluginGraphFiles(cache, linkedVFS, resolvedEntryPath);
+    if (cachedGraph) {
+      return cachedGraph;
+    }
+
+    const collected = new Map<string, string>();
+    const importSpecifiersByPath = new Map<string, string[]>();
+    const visit = async (filePath: string): Promise<void> => {
+      const normalizedPath = this.normalizePluginFilePath(filePath);
+      if (collected.has(normalizedPath)) {
+        return;
+      }
+      const analysis = await this.getLinkedPluginFileAnalysis(cache, linkedVFS, normalizedPath);
+      collected.set(normalizedPath, analysis.source);
+      importSpecifiersByPath.set(normalizedPath, analysis.importSpecifiers);
+
+      const specs = analysis.importSpecifiers;
+      for (const spec of specs) {
+        if (!spec.startsWith('./') && !spec.startsWith('../') && !spec.startsWith('/')) {
+          continue;
+        }
+        const normalizedSpec = this.stripPluginImportQuery(spec);
+        const nextPath = spec.startsWith('/')
+          ? this.normalizePluginFilePath(normalizedSpec)
+          : this.normalizePluginFilePath(
+              linkedVFS.join(linkedVFS.dirname(`/${normalizedPath}`), normalizedSpec).replace(/^\/+/, '')
+            );
+        const resolvedPath = await this.resolveLinkedPluginModulePath(linkedVFS, nextPath);
+        if (!resolvedPath) {
+          throw new Error(`Plugin import '${spec}' from '${normalizedPath}' does not exist`);
+        }
+        await visit(resolvedPath);
+      }
+    };
+
+    await visit(resolvedEntryPath);
+    const filePaths = [...collected.keys()];
+    cache.entryGraphs.set(resolvedEntryPath, {
+      filePaths
+    });
+    return {
+      files: filePaths.map((path) => ({
+        path,
+        source: collected.get(path) as string
+      })),
+      importSpecifiersByPath
+    };
+  }
+
   private static normalizePluginFiles(files: SystemPluginFileInput[]) {
     const normalized = new Map<string, string>();
     for (const file of files) {
@@ -1025,13 +1259,77 @@ export class SystemPluginService {
     if (!manifestFile) {
       throw new Error(`Plugin package is missing '${SYSTEM_PLUGIN_PACKAGE_MANIFEST}'`);
     }
+    return this.parsePackageManifest(manifestFile.source, SYSTEM_PLUGIN_PACKAGE_MANIFEST);
+  }
+
+  private static parsePackageManifest(source: string, fileName: string) {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(manifestFile.source);
+      parsed = JSON.parse(source);
     } catch (err) {
-      throw new Error(`Invalid '${SYSTEM_PLUGIN_PACKAGE_MANIFEST}': ${err}`);
+      throw new Error(`Invalid '${fileName}': ${err}`);
     }
     return this.normalizePackageManifest(parsed);
+  }
+
+  private static readPackageManifestFromLinkedFiles(files: SystemPluginFileInput[]) {
+    const devManifestFile = files.find((file) => file.path === SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST);
+    if (devManifestFile) {
+      return {
+        manifestFileName: SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST,
+        packageManifest: this.parsePackageManifest(devManifestFile.source, SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST)
+      };
+    }
+    return {
+      manifestFileName: SYSTEM_PLUGIN_PACKAGE_MANIFEST,
+      packageManifest: this.readPackageManifestFromFiles(files)
+    };
+  }
+
+  private static async readLinkedPackageManifest(
+    directory: string,
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>
+  ) {
+    const cache = this.getLinkedPluginGraphCache(directory);
+    const manifestCandidates = [SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST, SYSTEM_PLUGIN_PACKAGE_MANIFEST];
+    for (const manifestFileName of manifestCandidates) {
+      const manifestPath = linkedVFS.normalizePath(linkedVFS.join('/', manifestFileName));
+      if (!(await linkedVFS.exists(manifestPath))) {
+        continue;
+      }
+      const stat = await linkedVFS.stat(manifestPath);
+      if (!stat.isFile) {
+        continue;
+      }
+      if (
+        cache.manifest?.manifestFileName === manifestFileName &&
+        this.isLinkedPluginFileCacheCurrent(cache.manifest, stat)
+      ) {
+        return {
+          manifestFileName,
+          manifestSource: cache.manifest.manifestSource,
+          packageManifest: cache.manifest.packageManifest
+        };
+      }
+      const source = (await linkedVFS.readFile(manifestPath, { encoding: 'utf8' })) as string;
+      const fingerprint = this.getLinkedPluginFileCacheFingerprint(stat);
+      const packageManifest = this.parsePackageManifest(source, manifestFileName);
+      cache.manifest = {
+        manifestFileName,
+        manifestSource: source,
+        packageManifest,
+        modifiedAt: fingerprint.modifiedAt,
+        size: fingerprint.size
+      };
+      return {
+        manifestFileName,
+        manifestSource: source,
+        packageManifest
+      };
+    }
+    throw new Error(
+      `Linked plugin directory must contain '${SYSTEM_PLUGIN_DEV_PACKAGE_MANIFEST}' or '${SYSTEM_PLUGIN_PACKAGE_MANIFEST}' at its root`
+    );
   }
 
   private static resolvePackageManifestForInstall(input: InstallSystemPluginFilesInput) {
@@ -1119,9 +1417,13 @@ export class SystemPluginService {
     return Object.keys(result).length > 0 ? result : undefined;
   }
 
-  private static validateRelativeImportsStayWithinPlugin(filePath: string, source: string) {
-    const specs = this.collectImportSpecifiers(source);
-    for (const spec of specs) {
+  private static validateRelativeImportsStayWithinPlugin(
+    filePath: string,
+    source: string,
+    specs?: readonly string[]
+  ) {
+    const importSpecs = specs ?? this.collectImportSpecifiers(source);
+    for (const spec of importSpecs) {
       if (!spec.startsWith('./') && !spec.startsWith('../')) {
         continue;
       }
@@ -1241,6 +1543,9 @@ export class SystemPluginService {
       if (plugin.linked && typeof plugin.linked.directory !== 'string') {
         delete plugin.linked;
         dirty = true;
+      } else if (plugin.linked && 'entry' in plugin.linked && typeof plugin.linked.entry !== 'string') {
+        delete plugin.linked.entry;
+        dirty = true;
       }
     }
     if (dirty) {
@@ -1311,28 +1616,52 @@ export class SystemPluginService {
 
   private static async readLinkedPluginInput(directory: string, entryFileName?: string) {
     const linkedVFS = createLinkedDirectoryVFS(directory);
-    const files = await linkedVFS.readDirectory('/', {
-      includeHidden: true,
-      recursive: true
-    });
-    const inputFiles: SystemPluginFileInput[] = [];
-    for (const item of files) {
-      if (item.type !== 'file') {
+    try {
+      const { manifestFileName, manifestSource, packageManifest } = await this.readLinkedPackageManifest(
+        directory,
+        linkedVFS
+      );
+      const normalizedEntryFileName = this.normalizeEntryFileName(entryFileName ?? packageManifest.entry);
+      const graphFilesResult = await this.collectLinkedPluginGraphFiles(directory, linkedVFS, normalizedEntryFileName);
+      const graphFiles = graphFilesResult.files;
+      const packageFiles =
+        manifestFileName === SYSTEM_PLUGIN_PACKAGE_MANIFEST
+          ? [{ path: SYSTEM_PLUGIN_PACKAGE_MANIFEST, source: manifestSource }, ...graphFiles]
+          : graphFiles;
+      const validationFiles =
+        manifestFileName === SYSTEM_PLUGIN_PACKAGE_MANIFEST
+          ? packageFiles
+          : this.withPackageManifestFile(packageFiles, packageManifest);
+      this.validatePluginFiles(
+        validationFiles,
+        normalizedEntryFileName,
+        packageManifest.id,
+        graphFilesResult.importSpecifiersByPath
+      );
+      await this.ensureLinkedPluginDependencies(linkedVFS, packageManifest);
+      return {
+        packageManifest,
+        entryFileName: normalizedEntryFileName
+      };
+    } finally {
+      await linkedVFS.close();
+    }
+  }
+
+  private static async ensureLinkedPluginDependencies(
+    linkedVFS: ReturnType<typeof createLinkedDirectoryVFS>,
+    packageManifest: SystemPluginPackageManifest
+  ) {
+    const dependencies = Object.entries(packageManifest.dependencies ?? {});
+    if (dependencies.length === 0) {
+      return;
+    }
+    const lock = await readLock(linkedVFS, '/');
+    for (const [name, versionRange] of dependencies) {
+      if (lock?.dependencies?.[name]) {
         continue;
       }
-      inputFiles.push({
-        path: linkedVFS.relative(item.path, '/'),
-        source: (await linkedVFS.readFile(item.path, { encoding: 'utf8' })) as string
-      });
+      await installDeps(packageManifest.id, linkedVFS, '/', `${name}@${versionRange}`, undefined, true);
     }
-    const packageFiles = this.normalizeImportedPluginFiles(inputFiles);
-    const packageManifest = this.readPackageManifestFromFiles(packageFiles);
-    const normalizedEntryFileName = this.normalizeEntryFileName(entryFileName ?? packageManifest.entry);
-    this.validatePluginFiles(packageFiles, normalizedEntryFileName, packageManifest.id);
-    await linkedVFS.close();
-    return {
-      packageManifest,
-      entryFileName: normalizedEntryFileName
-    };
   }
 }

--- a/utility/editor/src/views/dlg/progressdlg.ts
+++ b/utility/editor/src/views/dlg/progressdlg.ts
@@ -8,6 +8,7 @@ export class DlgProgress extends DialogRenderer<void> {
   private _total2: number;
   private _twoLevel: boolean;
   private _barSize: ImGui.ImVec2;
+  private _message: string;
   constructor(id: string, width: number, twoLevel = false) {
     super(id, width, 0, false, true, true);
     this._current = 0;
@@ -16,6 +17,7 @@ export class DlgProgress extends DialogRenderer<void> {
     this._total2 = 1;
     this._twoLevel = twoLevel;
     this._barSize = new ImGui.ImVec2();
+    this._message = '';
   }
   setProgress(current: number, total: number) {
     this._current = current;
@@ -25,9 +27,15 @@ export class DlgProgress extends DialogRenderer<void> {
     this._current2 = current;
     this._total2 = total;
   }
+  setMessage(message: string) {
+    this._message = message;
+  }
   doRender(): void {
     this._barSize.x = ImGui.GetContentRegionAvail().x;
     this._barSize.y = 5;
+    if (this._message) {
+      ImGui.TextWrapped(this._message);
+    }
     ImGui.Text(`Finished: ${this._current} of ${this._total}`);
     ImGui.ProgressBar(this._current / this._total, this._barSize, '');
     if (this._twoLevel) {

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -22,6 +22,7 @@ import type {
 import { PathUtils, VFSError, VFS } from '@zephyr3d/base';
 import { VFSRenderer } from '../../components/vfsrenderer';
 import { CustomInputTextFlags, customTextInput } from '../../components/textinput';
+import { DlgProgress } from './progressdlg';
 
 function getPluginDependencyLines(plugin: SystemPluginRecord): string[] {
   const dependencies = Object.entries(plugin.dependencies ?? {}).sort(([a], [b]) => a.localeCompare(b));
@@ -805,41 +806,74 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
     this._listData.elements = await this._editor.listSystemPlugins();
   }
 
-  private async refreshPlugins() {
+  private async runPluginBusyTask(
+    title: string,
+    action: (updateProgress: (current: number, total: number, message: string) => void) => Promise<void>
+  ) {
+    const progress = new DlgProgress(`${title}##SystemPluginProgress`, 420);
+    progress.showModal();
+    progress.setProgress(0, 4);
+    progress.setMessage('准备中...');
     this._busy = true;
     try {
-      this._listData.elements = await this._editor.refreshSystemPlugins();
-    } catch {
+      await action((current, total, message) => {
+        progress.setProgress(current, total);
+        progress.setMessage(message);
+      });
+      progress.setProgress(4, 4);
+      progress.setMessage('操作完成');
     } finally {
+      progress.close();
       this._busy = false;
+    }
+  }
+
+  private async refreshPlugins() {
+    try {
+      await this.runPluginBusyTask('刷新插件', async (updateProgress) => {
+        updateProgress(1, 4, '正在扫描已 Link 的插件...');
+        this._listData.elements = await this._editor.refreshSystemPluginsWithProgress((message) => {
+          updateProgress(2, 4, message);
+        });
+        updateProgress(4, 4, '插件列表已刷新');
+      });
+    } catch {
     }
   }
 
   private async installPlugin() {
-    this._busy = true;
     try {
       const files = await FilePicker.chooseFiles(false, '.zip');
       if (files?.[0]) {
-        await this._editor.installSystemPluginFromFile(files[0]);
-        await this.reload();
+        await this.runPluginBusyTask('安装插件', async (updateProgress) => {
+          updateProgress(1, 4, '正在读取插件包...');
+          await this._editor.installSystemPluginFromFileWithProgress(files[0], (message) => {
+            updateProgress(2, 4, message);
+          });
+          updateProgress(3, 4, '正在刷新插件列表...');
+          await this.reload();
+          updateProgress(4, 4, '插件安装完成');
+        });
       }
     } catch {
-    } finally {
-      this._busy = false;
     }
   }
 
   private async installPluginFolder() {
-    this._busy = true;
     try {
       const files = await FilePicker.chooseDirectory();
       if (files?.length) {
-        await this._editor.installSystemPluginFromDirectory(files);
-        await this.reload();
+        await this.runPluginBusyTask('安装插件目录', async (updateProgress) => {
+          updateProgress(1, 4, '正在读取插件目录...');
+          await this._editor.installSystemPluginFromDirectoryWithProgress(files, (message) => {
+            updateProgress(2, 4, message);
+          });
+          updateProgress(3, 4, '正在刷新插件列表...');
+          await this.reload();
+          updateProgress(4, 4, '插件安装完成');
+        });
       }
     } catch {
-    } finally {
-      this._busy = false;
     }
   }
 
@@ -848,15 +882,21 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
     if (!desktop?.fs?.pickDirectory) {
       return;
     }
-    this._busy = true;
     try {
       const directory = await desktop.fs.pickDirectory({
         title: 'Select Plugin Directory',
         buttonLabel: 'Link Plugin'
       });
       if (directory) {
-        await this._editor.linkSystemPlugin(directory);
-        await this.reload();
+        await this.runPluginBusyTask('Link 插件', async (updateProgress) => {
+          updateProgress(1, 4, '正在读取插件目录...');
+          await this._editor.linkSystemPluginWithProgress(directory, undefined, (message) => {
+            updateProgress(2, 4, message);
+          });
+          updateProgress(3, 4, '正在刷新插件列表...');
+          await this.reload();
+          updateProgress(4, 4, '插件 Link 完成');
+        });
       }
     } catch (err) {
       await DlgMessageBoxEx.messageBoxEx(
@@ -867,8 +907,6 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
         0,
         true
       );
-    } finally {
-      this._busy = false;
     }
   }
 

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -7,6 +7,7 @@ import type { SystemPluginRecord } from '../../core/services/systemplugin';
 import { FilePicker } from '../../components/filepicker';
 import { templateEditorPluginFiles } from '../../core/build/templates';
 import { SystemPluginService } from '../../core/services/systemplugin';
+import { getDesktopAPI } from '../../core/services/desktop';
 import { DlgPromptName } from './promptnamedlg';
 import { DlgMessageBoxEx } from './messageexdlg';
 import { Dialog } from './dlg';
@@ -36,6 +37,12 @@ function getPluginDependencySummary(plugin: SystemPluginRecord): string {
     return 'Dependencies: none';
   }
   return `Dependencies: ${dependencies.map(([name, version]) => `${name}@${version}`).join(', ')}`;
+}
+
+function getPluginModeSummary(plugin: SystemPluginRecord): string {
+  return plugin.linked?.directory
+    ? `Mode: linked (${plugin.linked.directory})`
+    : 'Mode: installed package';
 }
 
 function normalizePluginSettingsForSchema(
@@ -173,6 +180,7 @@ class SystemPluginListView extends ListView<{}, SystemPluginRecord> {
         item.description ? '' : null,
         `Id: ${item.id}`,
         `Entry: ${item.entry}`,
+        getPluginModeSummary(item),
         ...((item.description || item.entry) && Object.keys(item.dependencies ?? {}).length > 0 ? [''] : []),
         ...getPluginDependencyLines(item)
       ]
@@ -416,12 +424,15 @@ class DlgPluginFiles extends DialogRenderer<void> {
 
   doRender(): void {
     ImGui.Text(`Plugin: ${this._plugin.id}`);
+    if (this._plugin.linked?.directory) {
+      ImGui.TextDisabled(`Linked to: ${this._plugin.linked.directory}`);
+    }
     ImGui.Separator();
-    if (ImGui.Button('Install Package...')) {
+    if (ImGui.Button('Install Package...') && !this._plugin.linked?.directory) {
       this.installPackage();
     }
     ImGui.SameLine();
-    if (ImGui.Button('Remove Package...')) {
+    if (ImGui.Button('Remove Package...') && !this._plugin.linked?.directory) {
       this.removePackage();
     }
     ImGui.Separator();
@@ -727,12 +738,19 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       ImGui.SetTooltip('Installs a plugin from directory');
     }
     ImGui.SameLine();
+    if (ImGui.Button('Link...') && !this._busy) {
+      this.linkPlugin();
+    }
+    if (ImGui.IsItemHovered()) {
+      ImGui.SetTooltip('Links a desktop plugin to an external dist directory for development');
+    }
+    ImGui.SameLine();
     if (ImGui.Button('New Template...') && !this._busy) {
       this.createTemplatePlugin();
     }
     ImGui.SameLine();
     if (ImGui.Button('Refresh') && !this._busy) {
-      this.reload().catch(() => undefined);
+      this.refreshPlugins().catch(() => undefined);
     }
 
     ImGui.Separator();
@@ -755,17 +773,18 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
         this.browseFiles(selected);
       }
       ImGui.SameLine();
-      if (ImGui.Button('Install Package...') && !this._busy) {
+      if (ImGui.Button('Install Package...') && !this._busy && !selected.linked?.directory) {
         this.installPluginPackage(selected);
       }
       ImGui.SameLine();
-      if (ImGui.Button('Remove Package...') && !this._busy) {
+      if (ImGui.Button('Remove Package...') && !this._busy && !selected.linked?.directory) {
         this.removePluginPackage(selected);
       }
       ImGui.SameLine();
       if (ImGui.Button('Settings...') && !this._busy) {
         this.editPluginSettings(selected);
       }
+      ImGui.TextWrapped(getPluginModeSummary(selected));
       ImGui.TextWrapped(getPluginDependencySummary(selected));
     } else {
       ImGui.TextDisabled('Select a plugin to inspect or remove it.');
@@ -779,6 +798,16 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
 
   private async reload() {
     this._listData.elements = await this._editor.listSystemPlugins();
+  }
+
+  private async refreshPlugins() {
+    this._busy = true;
+    try {
+      this._listData.elements = await this._editor.refreshSystemPlugins();
+    } catch {
+    } finally {
+      this._busy = false;
+    }
   }
 
   private async installPlugin() {
@@ -801,6 +830,27 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       const files = await FilePicker.chooseDirectory();
       if (files?.length) {
         await this._editor.installSystemPluginFromDirectory(files);
+        await this.reload();
+      }
+    } catch {
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  private async linkPlugin() {
+    const desktop = getDesktopAPI();
+    if (!desktop?.fs?.pickDirectory) {
+      return;
+    }
+    this._busy = true;
+    try {
+      const directory = await desktop.fs.pickDirectory({
+        title: 'Select Plugin Dist Directory',
+        buttonLabel: 'Link Plugin'
+      });
+      if (directory) {
+        await this._editor.linkSystemPlugin(directory, 'index.js');
         await this.reload();
       }
     } catch {

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -518,6 +518,7 @@ class DlgPluginFiles extends DialogRenderer<void> {
       'Remove Package',
       dependencyNames.map((name) => `${name}@${this._plugin.dependencies[name]}`),
       dependencyNames,
+      undefined,
       420,
       320
     );
@@ -746,7 +747,7 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       this.linkPlugin();
     }
     if (ImGui.IsItemHovered()) {
-      ImGui.SetTooltip('Links a desktop plugin to an external dist directory for development');
+      ImGui.SetTooltip('Links a desktop plugin directory for development. Supports plugin.dev.json source entry.');
     }
     ImGui.SameLine();
     if (ImGui.Button('New Template...') && !this._busy) {
@@ -850,14 +851,22 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
     this._busy = true;
     try {
       const directory = await desktop.fs.pickDirectory({
-        title: 'Select Plugin Dist Directory',
+        title: 'Select Plugin Directory',
         buttonLabel: 'Link Plugin'
       });
       if (directory) {
-        await this._editor.linkSystemPlugin(directory, 'index.js');
+        await this._editor.linkSystemPlugin(directory);
         await this.reload();
       }
-    } catch {
+    } catch (err) {
+      await DlgMessageBoxEx.messageBoxEx(
+        'Link Plugin Failed',
+        err instanceof Error ? err.message : String(err),
+        ['Close'],
+        480,
+        0,
+        true
+      );
     } finally {
       this._busy = false;
     }
@@ -1034,6 +1043,7 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
       'Remove Package',
       dependencyNames.map((name) => `${name}@${plugin.dependencies[name]}`),
       dependencyNames,
+      undefined,
       420,
       320
     );

--- a/utility/editor/src/views/dlg/systempluginsdlg.ts
+++ b/utility/editor/src/views/dlg/systempluginsdlg.ts
@@ -45,6 +45,10 @@ function getPluginModeSummary(plugin: SystemPluginRecord): string {
     : 'Mode: installed package';
 }
 
+const AUTO_SCRIPT_PATHS_BY_PLUGIN_ID: Record<string, string[]> = {
+  'com.0yao.zephyr3d-plugin': ['/assets/scripts/gpucloth.ts', '/assets/scripts/springtest.ts']
+};
+
 function normalizePluginSettingsForSchema(
   schema: EditorPluginSettingsSchema,
   settings: Record<string, unknown> | null | undefined
@@ -925,7 +929,37 @@ export class DlgSystemPlugins extends DialogRenderer<void> {
   private async removeSelected(plugin: SystemPluginRecord) {
     this._busy = true;
     try {
+      const autoScriptPaths = AUTO_SCRIPT_PATHS_BY_PLUGIN_ID[plugin.id] ?? [];
+      let shouldDeleteScripts = false;
+      if (autoScriptPaths.length > 0 && this._editor.currentProject && !this._editor.isProjectReadOnly()) {
+        const existingPaths: string[] = [];
+        for (const path of autoScriptPaths) {
+          if (await this._editor.projectFileExists(path)) {
+            existingPaths.push(path);
+          }
+        }
+        if (existingPaths.length > 0) {
+          const confirmed = await DlgMessageBoxEx.messageBoxEx(
+            'Remove plugin scripts',
+            `Also remove these generated project scripts?\n\n${existingPaths.join('\n')}`,
+            ['Remove Plugin And Scripts', 'Keep Scripts', 'Cancel'],
+            460,
+            0,
+            true
+          );
+          if (confirmed === 'Cancel') {
+            return;
+          }
+          shouldDeleteScripts = confirmed === 'Remove Plugin And Scripts';
+          if (shouldDeleteScripts) {
+            for (const path of existingPaths) {
+              await this._editor.deleteProjectFile(path);
+            }
+          }
+        }
+      }
       await this._editor.removeSystemPlugin(plugin.id);
+      void shouldDeleteScripts;
       await this.reload();
     } catch {
     } finally {


### PR DESCRIPTION
## 变更范围
- 插件源码 link 工作流
- 依赖分析与挂载逻辑
- 编辑器插件/项目加载进度提示

## 变更目标
在桌面插件 link 基础上，进一步支持源码级联调，并提升加载过程可观测性。

## 主要改动
- 支持编辑器插件开发态源码 Link 模式
- 增强 linked plugin 的依赖分析与入口处理
- 优化插件与项目加载时的进度提示

## 测试方式
- 链接本地源码插件目录
- 验证 `plugin.dev.json` / 入口分析 / 依赖处理逻辑
- 检查插件加载与项目加载的进度提示是否正常
```

备注：
`base`为 `pr/desktop-dev-plugin-link`