### PR TITLE
优化桌面端项目管理与资源导出流程

### DIFF
--- a/utility/editor/electron/main.cjs
+++ b/utility/editor/electron/main.cjs
@@ -2356,7 +2356,11 @@ function toPhysicalPath(root, vfsPath) {
   const relative = normalized.slice(1);
   const target = relative ? path.resolve(root, ...relative.split('/')) : path.resolve(root);
   const resolvedRoot = path.resolve(root);
-  if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
+  const relativeToRoot = path.relative(resolvedRoot, target);
+  const isInsideRoot =
+    relativeToRoot === '' ||
+    (!relativeToRoot.startsWith('..') && !path.isAbsolute(relativeToRoot));
+  if (!isInsideRoot) {
     throw new Error(`VFS path escapes storage root: ${vfsPath}`);
   }
   return { normalized, target };

--- a/utility/editor/src/components/vfsrenderer.ts
+++ b/utility/editor/src/components/vfsrenderer.ts
@@ -30,7 +30,7 @@ import { ResourceService } from '../core/services/resource';
 import { DlgSaveFile } from '../views/dlg/savefiledlg';
 import type { MeshMaterial, SharedModel } from '@zephyr3d/scene';
 import { getEngine, PBRBluePrintMaterial, SpriteBlueprintMaterial } from '@zephyr3d/scene';
-import { exportFile, exportMultipleFilesAsZip } from '../helpers/downloader';
+import { exportFile, exportMultipleFilesAsZip, exportMultipleFilesToDirectory } from '../helpers/downloader';
 import { matchesMimeType } from '../helpers/mimematch';
 import { buildPrimitiveGlbFromZmshContent } from '../helpers/primitiveglb';
 import { DlgImportOptions } from '../views/dlg/importoptionsdlg';
@@ -39,7 +39,7 @@ import type { Editor } from '../core/editor';
 import type { RuntimeEditorAssetContext, RuntimeEditorMenuContext } from '../core/plugin';
 import type { PropertyAccessor } from '@zephyr3d/scene';
 import { AssetThumbnailService, ImageAssetThumbnailProvider } from './assetthumbnail';
-import { getDesktopAPI } from '../core/services/desktop';
+import { getDesktopAPI, isDesktopApp } from '../core/services/desktop';
 import { ElectronFS } from '../core/services/electronfs';
 
 export type FileInfo = {
@@ -1186,12 +1186,16 @@ export class VFSRenderer extends makeObservable(Disposable)<{
     }
   }
 
-  exportSelectedItems() {
+  async exportSelectedItems() {
     if (this.selectedItems.size === 0) {
       return;
     }
     const items = Array.from(this.selectedItems);
-    if (items.length === 1 && !('subDir' in items[0])) {
+    const selectedPaths = items.map((item) => ('subDir' in item ? item.path : item.meta.path));
+    const preserveAssetsPath = selectedPaths.every(
+      (path) => path === '/assets' || this._vfs.isParentOf('/assets', path)
+    );
+    if (items.length === 1 && !('subDir' in items[0]) && !preserveAssetsPath) {
       const filename = this._vfs.basename(items[0].meta.path);
       this._vfs.readFile(items[0].meta.path, { encoding: 'binary' }).then((data) => {
         exportFile(data as ArrayBuffer, filename);
@@ -1203,7 +1207,71 @@ export class VFSRenderer extends makeObservable(Disposable)<{
       const dirs = (items.filter((items) => 'subDir' in items) as DirectoryInfo[]).map(
         (item: DirectoryInfo) => item.path
       );
-      exportMultipleFilesAsZip(files, dirs, 'export.zip', this._vfs);
+      const dlgProgressBar = new DlgProgress('Export Assets##ExportProgress', 320);
+      dlgProgressBar.showModal();
+      dlgProgressBar.setProgress(0, 1);
+      const zipFilename =
+        items.length === 1
+          ? `${this._vfs.basename('subDir' in items[0] ? items[0].path : items[0].meta.path)}.zip`
+          : preserveAssetsPath
+            ? 'assets-export.zip'
+            : 'export.zip';
+        try {
+          if (preserveAssetsPath && isDesktopApp()) {
+            const desktop = getDesktopAPI();
+            const targetRoot = await desktop?.fs.pickDirectory({
+              title: 'Select Export Directory',
+              buttonLabel: 'Export Here'
+            });
+            if (!targetRoot) {
+              return;
+            }
+            const targetFS = new ElectronFS(`project:${targetRoot}`);
+            const resetPaths: string[] = [];
+            try {
+              if (await targetFS.exists('/assets')) {
+                const existingEntries = await targetFS.readDirectory('/assets', {
+                  includeHidden: true,
+                  recursive: false
+                });
+                if (existingEntries.length > 0) {
+                  const action = await DlgMessageBoxEx.messageBoxEx(
+                    'Export Assets',
+                    'The target directory already contains an assets folder.\n\nReplace it, merge into it, or cancel?',
+                    ['Replace', 'Merge', 'Cancel'],
+                    420,
+                    0,
+                    true
+                  );
+                  if (action === 'Cancel' || !action) {
+                    return;
+                  }
+                  if (action === 'Replace') {
+                    resetPaths.push('/assets');
+                  }
+                }
+              }
+            } finally {
+              await targetFS.close();
+            }
+            const exported = await exportMultipleFilesToDirectory(files, dirs, this._vfs, {
+              preserveProjectPaths: true,
+              targetRoot,
+              resetPaths,
+              onProgress: (current, total) => dlgProgressBar.setProgress(current, total)
+            });
+            if (!exported) {
+              return;
+            }
+          } else {
+            await exportMultipleFilesAsZip(files, dirs, zipFilename, this._vfs, {
+              preserveProjectPaths: preserveAssetsPath,
+              onProgress: (current, total) => dlgProgressBar.setProgress(current, total)
+            });
+          }
+      } finally {
+          dlgProgressBar.close();
+        }
     }
   }
 

--- a/utility/editor/src/controllers/scenecontroller.ts
+++ b/utility/editor/src/controllers/scenecontroller.ts
@@ -108,6 +108,22 @@ export class SceneController extends BaseController<SceneModel, SceneView> {
         }
         break;
       }
+      case 'OPEN_PROJECT_DIRECTORY': {
+        await this.sceneAction('CLOSE_PROJECT', arg);
+        let result: { id: Nullable<string>; err: Nullable<string> };
+        if (!this._editor.currentProject) {
+          result = await this._editor.openProjectDirectory(arg?.path);
+        } else {
+          result = {
+            id: null,
+            err: 'User refused to open project directory'
+          };
+        }
+        if (arg?.cb) {
+          arg.cb(result);
+        }
+        break;
+      }
       case 'NEW_PROJECT': {
         await this.sceneAction('CLOSE_PROJECT', arg);
         let id: string = null;

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -636,7 +636,29 @@ export class Editor {
   async importProject() {
     const files = await FilePicker.chooseDirectory();
     if (files?.length > 0) {
-      const uuid = await ProjectService.importProject(files);
+      let directory: string | undefined;
+      let projectName: string | undefined;
+      if (isDesktopApp()) {
+        const projectFile = files.find((file) => file.name === 'project.json');
+        const defaultName = projectFile
+          ? PathUtils.basename(PathUtils.dirname(projectFile.webkitRelativePath || projectFile.name))
+          : '';
+        const result = await Dialog.createProject(
+          'Import Project',
+          defaultName,
+          '',
+          'Select or enter a parent directory',
+          'Select Import Parent Directory',
+          'Import',
+          560
+        );
+        if (!result) {
+          return;
+        }
+        directory = result.directory;
+        projectName = result.name;
+      }
+      const uuid = await ProjectService.importProject(files, directory, projectName);
       if (uuid) {
         const project = await ProjectService.openProject(uuid);
         const settings = await ProjectService.getCurrentProjectSettings();
@@ -682,7 +704,14 @@ export class Editor {
     }
   ) {
     if (!name && isDesktopApp()) {
-      const result = await Dialog.createProject('Create Project', '', '', 560);
+      const result = await Dialog.createProject(
+        'Create Project',
+        '',
+        '',
+        'Select or enter a parent directory',
+        'Select Project Parent Directory',
+        560
+      );
       if (!result) {
         return null;
       }
@@ -742,7 +771,17 @@ export class Editor {
         const projects = await ProjectService.listProjects();
         const names = projects.map((project) => this.formatProjectLabel(project));
         const ids = projects.map((project) => project.uuid);
-        id = await Dialog.openFromList('Open Project', names, ids, 400, 400);
+        id = await Dialog.openFromList(
+          'Open Project',
+          names,
+          ids,
+          isDesktopApp() ? 'Open Project Directory...' : '',
+          400,
+          400
+        );
+      }
+      if (id === '__action__:Open Project Directory...') {
+        return await this.openProjectDirectory();
       }
       if (id) {
         this._isRemoteProject = false;
@@ -775,6 +814,23 @@ export class Editor {
         id,
         err: null
       };
+    } catch (err) {
+      return {
+        id: null,
+        err: `${err}`
+      };
+    }
+  }
+  async openProjectDirectory(directory?: string): Promise<{ id: Nullable<string>; err: Nullable<string> }> {
+    try {
+      const id = await ProjectService.registerProjectDirectory(directory);
+      if (!id) {
+        return {
+          id: null,
+          err: null
+        };
+      }
+      return await this.openProject(id);
     } catch (err) {
       return {
         id: null,

--- a/utility/editor/src/core/services/project.ts
+++ b/utility/editor/src/core/services/project.ts
@@ -5,7 +5,7 @@ import { fileListFileName, libDir, projectFileName } from '../build/templates';
 import { DlgMessage } from '../../views/dlg/messagedlg';
 import { installDeps } from '../build/dep';
 import { createEditorMetaVFS, createProjectVFS, deleteProjectVFS } from './storage';
-import { getDesktopAPI } from './desktop';
+import { getDesktopAPI, type DesktopFSScope } from './desktop';
 
 export type ProjectInfo = {
   name: string;
@@ -90,6 +90,16 @@ export function getProjectStorageId(project: ProjectInfo): string {
   return project.path || project.uuid;
 }
 
+function resolveDesktopProjectDirectory(parentDirectory: string, projectName: string): string {
+  const normalizedParent = String(parentDirectory || '').trim().replace(/[\\/]+$/, '');
+  const normalizedName = String(projectName || '').trim().replace(/[\\/]+/g, ' ').trim();
+  if (!normalizedParent || !normalizedName) {
+    return normalizedParent || normalizedName;
+  }
+  const separator = normalizedParent.includes('\\') ? '\\' : '/';
+  return `${normalizedParent}${separator}${normalizedName}`;
+}
+
 const metaVFS = createEditorMetaVFS();
 let projectVFS: VFS = metaVFS;
 
@@ -119,18 +129,18 @@ export class ProjectService {
     return this._currentProjectInfo ? getProjectStorageId(this._currentProjectInfo) : '';
   }
   static async listProjects(): Promise<ProjectInfo[]> {
-    const manifest = await this.readManifest();
+    const manifest = await this.readManifest(true);
     return Object.values(manifest.projectList).map((project) => normalizeProjectInfo(project));
   }
   static async getRecentProjects(): Promise<ProjectInfo[]> {
-    const manifest = await this.readManifest();
+    const manifest = await this.readManifest(true);
     return Object.keys(manifest.history)
       .sort((a, b) => manifest.history[b] - manifest.history[a])
       .map((v) => manifest.projectList[v])
       .map((project) => normalizeProjectInfo(project))
       .filter((v) => !!v);
   }
-  static async importProject(files: File[]) {
+  static async importProject(files: File[], directory?: string, nameOverride?: string) {
     let baseDir = '';
     for (const f of files) {
       if (f.name === projectFileName) {
@@ -142,15 +152,32 @@ export class ProjectService {
       await DlgMessage.messageBox('Error', 'No project found in specified directory');
       return '';
     }
-    const name = PathUtils.basename(baseDir);
-    const uuid = randomUUID();
-    const manifest = await this.readManifest();
-    manifest.projectList[uuid] = {
+    const name = nameOverride?.trim() || PathUtils.basename(baseDir);
+    const desktop = getDesktopAPI();
+    if (desktop && directory && !isAbsoluteProjectId(directory)) {
+      throw new Error(
+        `Import project failed: Parent directory must be an absolute path, got <${directory}>`
+      );
+    }
+    const selectedDirectory = desktop
+      ? directory ||
+        (desktop.fs.pickDirectory
+          ? await desktop.fs.pickDirectory({
+              title: 'Select Import Parent Directory',
+              buttonLabel: 'Select Folder'
+            })
+          : '')
+      : randomUUID();
+    if (!selectedDirectory) {
+      return '';
+    }
+    const uuid = desktop ? resolveDesktopProjectDirectory(selectedDirectory, name) : selectedDirectory;
+    const project = normalizeProjectInfo({
       name,
       uuid
-    };
-    await this.writeManifest(manifest);
-    const vfs = createProjectVFS(uuid);
+    });
+    await this.ensureProjectLocationAvailable(project);
+    const vfs = createProjectVFS(getProjectStorageId(project));
     try {
       for (const f of files) {
         const path = `/${PathUtils.relative(baseDir, f.webkitRelativePath)}`;
@@ -166,6 +193,9 @@ export class ProjectService {
     } finally {
       await vfs.close();
     }
+    const manifest = await this.readManifest();
+    manifest.projectList[uuid] = project;
+    await this.writeManifest(manifest);
     return uuid;
   }
   static async createProject(name: string, directory?: string) {
@@ -175,21 +205,22 @@ export class ProjectService {
     const desktop = getDesktopAPI();
     if (desktop && directory && !isAbsoluteProjectId(directory)) {
       throw new Error(
-        `Create project failed: Project directory must be an absolute path, got <${directory}>`
+        `Create project failed: Parent directory must be an absolute path, got <${directory}>`
       );
     }
-    const uuid = desktop
+    const selectedDirectory = desktop
       ? directory ||
         (desktop.fs.pickDirectory
           ? await desktop.fs.pickDirectory({
-              title: 'Select Project Directory',
+              title: 'Select Project Parent Directory',
               buttonLabel: 'Select Folder'
             })
           : '')
       : randomUUID();
-    if (!uuid) {
+    if (!selectedDirectory) {
       return '';
     }
+    const uuid = desktop ? resolveDesktopProjectDirectory(selectedDirectory, name) : selectedDirectory;
     const project = normalizeProjectInfo({
       name,
       uuid
@@ -210,6 +241,34 @@ export class ProjectService {
     manifest.projectList[uuid] = project;
     await this.writeManifest(manifest);
     return uuid;
+  }
+  static async registerProjectDirectory(directory?: string) {
+    const desktop = getDesktopAPI();
+    if (!desktop) {
+      throw new Error('Open project directory is only supported in the desktop editor');
+    }
+    if (directory && !isAbsoluteProjectId(directory)) {
+      throw new Error(
+        `Open project directory failed: Project directory must be an absolute path, got <${directory}>`
+      );
+    }
+    const projectDirectory =
+      directory ||
+      (desktop.fs.pickDirectory
+        ? await desktop.fs.pickDirectory({
+            title: 'Select Project Directory',
+            buttonLabel: 'Select Folder'
+          })
+        : '');
+    if (!projectDirectory) {
+      return '';
+    }
+    const project = await this.loadProjectFromDirectory(projectDirectory);
+    const manifest = await this.readManifest();
+    manifest.projectList[project.uuid] = project;
+    manifest.history[project.uuid] = Date.now();
+    await this.writeManifest(manifest);
+    return project.uuid;
   }
   static async getCurrentProjectInfo() {
     if (!this._currentProject) {
@@ -257,10 +316,16 @@ export class ProjectService {
     }
   }
   static async openProject(uuid: string): Promise<ProjectInfo> {
-    const manifest = await this.readManifest();
+    const manifest = await this.readManifest(true);
     const info = normalizeProjectInfo(manifest.projectList[uuid]);
     if (!info) {
       throw new Error(`Cannot open project: Project <${uuid}> not found`);
+    }
+    if (!(await this.isProjectAvailable(info))) {
+      delete manifest.projectList[uuid];
+      delete manifest.history[uuid];
+      await this.writeManifest(manifest);
+      throw new Error(`Cannot open project: Project <${uuid}> is no longer available`);
     }
     if (this._currentProject) {
       throw new Error('Current project must be closed before opening another project');
@@ -309,7 +374,7 @@ export class ProjectService {
     if (this._currentProject === uuid) {
       throw new Error('Project must be closed before delete it');
     }
-    const manifest = await this.readManifest();
+    const manifest = await this.readManifest(true);
     const info = normalizeProjectInfo(manifest.projectList[uuid]);
     if (info) {
       delete manifest.projectList[uuid];
@@ -328,18 +393,43 @@ export class ProjectService {
       this._currentProjectInfo = { ...normalizedProject };
     }
   }
-  private static async readManifest() {
+  private static async readManifest(validate = false) {
     const exists = await metaVFS.exists(ProjectService.PROJECT_MANIFEST);
-    if (!exists) {
-      return {
-        history: {},
-        projectList: {}
-      };
+    const manifest = !exists
+      ? {
+          history: {},
+          projectList: {}
+        }
+      : (((JSON.parse(
+          (await metaVFS.readFile(ProjectService.PROJECT_MANIFEST, {
+            encoding: 'utf8'
+          })) as string
+        ) as EditorManifest) ?? {
+          history: {},
+          projectList: {}
+        }) as EditorManifest);
+    if (!validate) {
+      return manifest;
     }
-    const content = (await metaVFS.readFile(ProjectService.PROJECT_MANIFEST, {
-      encoding: 'utf8'
-    })) as string;
-    return JSON.parse(content) as EditorManifest;
+    let dirty = false;
+    for (const uuid of Object.keys(manifest.projectList)) {
+      const info = normalizeProjectInfo(manifest.projectList[uuid]);
+      if (!info || !(await this.isProjectAvailable(info))) {
+        delete manifest.projectList[uuid];
+        delete manifest.history[uuid];
+        dirty = true;
+      }
+    }
+    for (const uuid of Object.keys(manifest.history)) {
+      if (!manifest.projectList[uuid]) {
+        delete manifest.history[uuid];
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      await this.writeManifest(manifest);
+    }
+    return manifest;
   }
   private static async writeManifest(manifest: EditorManifest) {
     await metaVFS.writeFile(ProjectService.PROJECT_MANIFEST, JSON.stringify(manifest, null, 2), {
@@ -348,8 +438,46 @@ export class ProjectService {
     });
   }
   private static async getProjectInfo(uuid: string) {
-    const manifest = await this.readManifest();
+    const manifest = await this.readManifest(true);
     return normalizeProjectInfo(manifest.projectList[uuid]);
+  }
+  private static async loadProjectFromDirectory(directory: string): Promise<ProjectInfo> {
+    const project = normalizeProjectInfo({
+      name: '',
+      uuid: directory
+    });
+    const vfs = createProjectVFS(getProjectStorageId(project));
+    try {
+      const exists = await vfs.exists(`/${projectFileName}`);
+      if (!exists) {
+        throw new Error(`Open project directory failed: <${directory}> does not contain ${projectFileName}`);
+      }
+      const content = (await vfs.readFile(`/${projectFileName}`, { encoding: 'utf8' })) as string;
+      const settings = normalizeProjectSettings(JSON.parse(content));
+      const name = settings.title?.trim() || PathUtils.basename(directory.replace(/\\/g, '/'));
+      return normalizeProjectInfo({
+        name,
+        uuid: directory
+      });
+    } finally {
+      await vfs.close();
+    }
+  }
+  private static async isProjectAvailable(project: ProjectInfo) {
+    const storageId = getProjectStorageId(project);
+    if (!storageId) {
+      return false;
+    }
+    const desktop = getDesktopAPI();
+    if (desktop?.fs?.exists) {
+      return await desktop.fs.exists(`project:${storageId}` as DesktopFSScope, `/${projectFileName}`);
+    }
+    const vfs = createProjectVFS(storageId);
+    try {
+      return await vfs.exists(`/${projectFileName}`);
+    } finally {
+      await vfs.close();
+    }
   }
   private static async ensureProjectLocationAvailable(project: ProjectInfo) {
     const storageId = getProjectStorageId(project);

--- a/utility/editor/src/helpers/downloader.ts
+++ b/utility/editor/src/helpers/downloader.ts
@@ -1,6 +1,8 @@
 import { configure, ZipWriter } from '@zip.js/zip.js';
 import type { VFS } from '@zephyr3d/base';
 import * as streamSaver from 'streamsaver';
+import { getDesktopAPI } from '../core/services/desktop';
+import { ElectronFS } from '../core/services/electronfs';
 import { ProjectService } from '../core/services/project';
 
 export class ZipDownloader {
@@ -63,40 +65,142 @@ export async function exportMultipleFilesAsZip(
   files: string[],
   directories: string[],
   zipFilename: string,
-  vfs: VFS = ProjectService.VFS
+  vfs: VFS = ProjectService.VFS,
+  options?: {
+    preserveProjectPaths?: boolean;
+    onProgress?: (current: number, total: number) => void;
+  }
 ) {
   const zipDownloader = new ZipDownloader(zipFilename);
   const zipWriter = zipDownloader.zipWriter;
+  const { commonPrefix, directoryEntries, uniqueFiles } = await collectExportEntries(files, directories, vfs, options);
+  const totalSteps = directoryEntries.length + uniqueFiles.length || 1;
+  let currentStep = 0;
+  options?.onProgress?.(currentStep, totalSteps);
+  for (const dir of directoryEntries) {
+    await zipWriter.add(`${dir}/`, new Blob([]).stream());
+    options?.onProgress?.(++currentStep, totalSteps);
+  }
+  for (const f of uniqueFiles) {
+    const content = (await vfs.readFile(f, { encoding: 'binary' })) as ArrayBuffer;
+    await zipWriter.add(f.slice(commonPrefix.length), new Blob([content]).stream());
+    options?.onProgress?.(++currentStep, totalSteps);
+  }
+  await zipDownloader.finish();
+}
+
+export async function exportMultipleFilesToDirectory(
+  files: string[],
+  directories: string[],
+  vfs: VFS = ProjectService.VFS,
+  options?: {
+    preserveProjectPaths?: boolean;
+    targetRoot?: string;
+    resetPaths?: string[];
+    onProgress?: (current: number, total: number) => void;
+  }
+) {
+  const desktop = getDesktopAPI();
+  if (!desktop?.fs.pickDirectory) {
+    return false;
+  }
+  const targetRoot =
+    options?.targetRoot ||
+    (await desktop.fs.pickDirectory({
+      title: 'Select Export Directory',
+      buttonLabel: 'Export Here'
+    }));
+  if (!targetRoot) {
+    return false;
+  }
+  const outputFS = new ElectronFS(`project:${targetRoot}`);
+  const { commonPrefix, directoryEntries, uniqueFiles } = await collectExportEntries(files, directories, vfs, options);
+  try {
+    const totalSteps = directoryEntries.length + uniqueFiles.length || 1;
+    let currentStep = 0;
+    options?.onProgress?.(currentStep, totalSteps);
+    for (const resetPath of options?.resetPaths ?? []) {
+      if (await outputFS.exists(resetPath)) {
+        await outputFS.deleteDirectory(resetPath, true);
+      }
+    }
+    for (const dir of directoryEntries) {
+      await outputFS.makeDirectory(`/${dir}`, true);
+      options?.onProgress?.(++currentStep, totalSteps);
+    }
+    for (const f of uniqueFiles) {
+      const relativePath = f.slice(commonPrefix.length);
+      const targetPath = `/${relativePath}`;
+      const parentDir = outputFS.dirname(targetPath);
+      if (parentDir && parentDir !== '/') {
+        await outputFS.makeDirectory(parentDir, true);
+      }
+      const content = (await vfs.readFile(f, { encoding: 'binary' })) as ArrayBuffer;
+      await outputFS.writeFile(targetPath, content, {
+        encoding: 'binary',
+        create: true
+      });
+      options?.onProgress?.(++currentStep, totalSteps);
+    }
+    return true;
+  } finally {
+    await outputFS.close();
+  }
+}
+
+async function collectExportEntries(
+  files: string[],
+  directories: string[],
+  vfs: VFS,
+  options?: {
+    preserveProjectPaths?: boolean;
+  }
+) {
   const fileSet: Set<string> = new Set();
+  const directorySet: Set<string> = new Set();
   const fileList = [...files];
   for (const dir of directories) {
     const path = vfs.normalizePath(dir);
-    const pattern = path === '/' ? '/**/*' : `${path}/**/*`;
-    const subFiles = await vfs.glob(pattern, { includeDirs: false });
-    for (const f of subFiles) {
-      fileList.push(f.path);
+    directorySet.add(path);
+    const entries = await vfs.readDirectory(path, {
+      includeHidden: true,
+      recursive: true
+    });
+    for (const entry of entries) {
+      if (entry.type === 'directory') {
+        directorySet.add(vfs.normalizePath(entry.path));
+      } else {
+        fileList.push(entry.path);
+      }
     }
   }
   for (const f of fileList) {
     const filename = vfs.normalizePath(f);
     fileSet.add(filename);
   }
-  // Remove common path prefix
   const uniqueFiles = Array.from(fileSet);
-  const prefixes = uniqueFiles.map((f) => vfs.dirname(f));
-  let commonPrefix = prefixes[0];
-  while (commonPrefix) {
-    if (prefixes.every((p) => p.startsWith(commonPrefix))) {
-      break;
+  const uniqueDirectories = Array.from(directorySet).filter((dir) => dir && dir !== '/');
+  let commonPrefix = options?.preserveProjectPaths ? '/' : '';
+  if (!commonPrefix) {
+    const prefixSources = uniqueFiles.length > 0 ? uniqueFiles.map((f) => vfs.dirname(f)) : uniqueDirectories;
+    commonPrefix = prefixSources[0] ?? '/';
+    while (commonPrefix) {
+      if (prefixSources.every((p) => p.startsWith(commonPrefix))) {
+        break;
+      }
+      commonPrefix = vfs.dirname(commonPrefix);
     }
-    commonPrefix = vfs.dirname(commonPrefix);
   }
   if (commonPrefix && !commonPrefix.endsWith('/')) {
     commonPrefix += '/';
   }
-  for (const f of uniqueFiles) {
-    const content = (await vfs.readFile(f, { encoding: 'binary' })) as ArrayBuffer;
-    await zipWriter.add(f.slice(commonPrefix.length), new Blob([content]).stream());
-  }
-  await zipDownloader.finish();
+  const directoryEntries = uniqueDirectories
+    .map((dir) => dir.slice(commonPrefix.length))
+    .filter((dir) => !!dir)
+    .sort((a, b) => a.length - b.length || a.localeCompare(b));
+  return {
+    commonPrefix,
+    directoryEntries,
+    uniqueFiles
+  };
 }

--- a/utility/editor/src/views/dlg/createprojectdlg.ts
+++ b/utility/editor/src/views/dlg/createprojectdlg.ts
@@ -18,12 +18,31 @@ export class DlgCreateProject extends DialogRenderer<CreateProjectResult | null>
     title: string,
     defaultName?: string,
     defaultDirectory?: string,
+    directoryPlaceholder?: string,
+    directoryPickerTitle?: string,
+    confirmLabel?: string,
     width?: number
   ): Promise<CreateProjectResult | null> {
-    return new DlgCreateProject(title, defaultName, defaultDirectory, width).showModal();
+    return new DlgCreateProject(
+      title,
+      defaultName,
+      defaultDirectory,
+      directoryPlaceholder,
+      directoryPickerTitle,
+      confirmLabel,
+      width
+    ).showModal();
   }
 
-  constructor(id: string, defaultName = '', defaultDirectory = '', width = 560) {
+  constructor(
+    id: string,
+    defaultName = '',
+    defaultDirectory = '',
+    private readonly _directoryPlaceholder = 'Select or enter a project directory',
+    private readonly _directoryPickerTitle = 'Select Project Directory',
+    private readonly _confirmLabel = 'Create',
+    width = 560
+  ) {
     super(id, width, 0, true, true);
     this._name = [defaultName];
     this._directory = [defaultDirectory];
@@ -43,7 +62,7 @@ export class DlgCreateProject extends DialogRenderer<CreateProjectResult | null>
 
     const btnWidth = imGuiCalcTextSize('...').x + ImGui.GetStyle().FramePadding.x * 2;
     ImGui.PushItemWidth(ImGui.GetContentRegionAvail().x - btnWidth - ImGui.GetStyle().ItemSpacing.x);
-    customTextInput('##ProjectDirectory', this._directory, 'Select or enter a project directory');
+    customTextInput('##ProjectDirectory', this._directory, this._directoryPlaceholder);
     ImGui.PopItemWidth();
     ImGui.SameLine();
     if (ImGui.Button('...', new ImGui.ImVec2(btnWidth, 0))) {
@@ -51,7 +70,7 @@ export class DlgCreateProject extends DialogRenderer<CreateProjectResult | null>
     }
 
     const canCreate = !!this._name[0].trim() && !!this._directory[0].trim();
-    if (ImGui.Button('Create') && canCreate) {
+    if (ImGui.Button(this._confirmLabel) && canCreate) {
       this.close({
         name: this._name[0].trim(),
         directory: this._directory[0].trim()
@@ -71,7 +90,7 @@ export class DlgCreateProject extends DialogRenderer<CreateProjectResult | null>
     this._pickingDirectory = true;
     desktop.fs
       .pickDirectory({
-        title: 'Select Project Directory',
+        title: this._directoryPickerTitle,
         defaultPath: this._directory[0] || undefined,
         buttonLabel: 'Select Folder'
       })

--- a/utility/editor/src/views/dlg/dlg.ts
+++ b/utility/editor/src/views/dlg/dlg.ts
@@ -117,10 +117,11 @@ export class Dialog {
     title: string,
     names: string[],
     ids: string[],
+    extraActionLabel?: string,
     width?: number,
     height?: number
   ): Promise<string> {
-    return DlgOpen.openFromList(title, names, ids, width, height);
+    return DlgOpen.openFromList(title, names, ids, extraActionLabel, width, height);
   }
   public static async promptName(
     title: string,
@@ -134,9 +135,20 @@ export class Dialog {
     title: string,
     defaultName?: string,
     defaultDirectory?: string,
+    directoryPlaceholder?: string,
+    directoryPickerTitle?: string,
+    confirmLabel?: string,
     width?: number
   ): Promise<CreateProjectResult | null> {
-    return DlgCreateProject.createProject(title, defaultName, defaultDirectory, width);
+    return DlgCreateProject.createProject(
+      title,
+      defaultName,
+      defaultDirectory,
+      directoryPlaceholder,
+      directoryPickerTitle,
+      confirmLabel,
+      width
+    );
   }
   public static async rename(title: string, name: string, width?: number): Promise<string> {
     return DlgRename.rename(title, name, width);

--- a/utility/editor/src/views/dlg/opendlg.ts
+++ b/utility/editor/src/views/dlg/opendlg.ts
@@ -9,12 +9,20 @@ export class DlgOpen extends DialogRenderer<string> {
     title: string,
     names: string[],
     ids: string[],
+    extraActionLabel?: string,
     width?: number,
     height?: number
   ): Promise<string> {
-    return new DlgOpen(title, names, ids, width, height).showModal();
+    return new DlgOpen(title, names, ids, extraActionLabel, width, height).showModal();
   }
-  constructor(id: string, names: string[], ids: string[], width: number, height: number) {
+  constructor(
+    id: string,
+    names: string[],
+    ids: string[],
+    private readonly _extraActionLabel = '',
+    width: number,
+    height: number
+  ) {
     super(id, width, height);
     this._names = names.slice();
     this._ids = ids.slice();
@@ -35,6 +43,12 @@ export class DlgOpen extends DialogRenderer<string> {
     if (ImGui.Button('Open')) {
       if (this._selected[0] >= 0 && this._selected[0] < this._ids.length) {
         this.close(this._ids[this._selected[0]]);
+      }
+    }
+    if (this._extraActionLabel) {
+      ImGui.SameLine();
+      if (ImGui.Button(this._extraActionLabel)) {
+        this.close(`__action__:${this._extraActionLabel}`);
       }
     }
     ImGui.SameLine();


### PR DESCRIPTION
## 变更范围
- 桌面端项目导入与打开流程
- 项目清单有效性校验
- 资源导出与 assets 目录结构保留

## 变更目标
改善桌面端项目管理体验，并让资源导出流程更符合真实目录使用场景。

## 主要改动
- 优化 Import Project 流程
- 增加项目目录有效性校验
- 支持直接打开项目目录
- 优化资源导出，并支持保留 `assets` 目录结构

## 测试方式
- 导入桌面项目
- 打开已存在项目目录
- 验证无效项目目录会被正确拦截或清理
- 导出资源并确认 `assets` 目录结构保留符合预期