### PR TITLE
优化编辑器场景与资产工作流反馈

### DIFF
--- a/libs/scene/src/utility/serialization/scene/node.ts
+++ b/libs/scene/src/utility/serialization/scene/node.ts
@@ -109,7 +109,12 @@ export function getSceneNodeClass(manager: ResourceManager): SerializableClass {
     ) {
       const scene = ctx instanceof Scene ? ctx : ctx.scene;
       if (init?.prefabId) {
-        const prefabData = (await manager.loadPrefabContent(init.prefabId))!.data as DiffValue;
+        const prefabContent = await manager.loadPrefabContent(init.prefabId);
+        if (!prefabContent?.data) {
+          console.warn(`Skip scene node because prefab asset is missing: ${init.prefabId}`);
+          return { obj: null, loadProps: false };
+        }
+        const prefabData = prefabContent.data as DiffValue;
         const nodeData = normalizeSerializedSceneNodeData(
           applyPatch(prefabData, init.patch ?? []) as DiffValue
         );
@@ -125,7 +130,13 @@ export function getSceneNodeClass(manager: ResourceManager): SerializableClass {
         return { obj: sceneNode, loadProps: false };
       }
       if (init?.assetId) {
-        const fetchedModel = await manager.fetchModel(init.assetId, scene!);
+        let fetchedModel: SceneNode | null = null;
+        try {
+          fetchedModel = (await manager.fetchModel(init.assetId, scene!)) ?? null;
+        } catch (err) {
+          console.warn(`Skip scene node because model asset failed to load: ${init.assetId}: ${err}`);
+          fetchedModel = null;
+        }
         const sceneNode = fetchedModel ?? null;
         if (sceneNode) {
           const originalAssetId = manager.getAssetId(sceneNode);
@@ -140,6 +151,8 @@ export function getSceneNodeClass(manager: ResourceManager): SerializableClass {
             manager.setAssetId(sceneNode, originalAssetId ?? init.assetId);
           }
           sceneNode.parent = ctx instanceof SceneNode ? ctx : ctx.rootNode;
+        } else {
+          console.warn(`Skip scene node because model asset is missing: ${init.assetId}`);
         }
         return { obj: sceneNode, loadProps: false };
       }

--- a/utility/editor/src/commands/scenecommands.ts
+++ b/utility/editor/src/commands/scenecommands.ts
@@ -39,6 +39,16 @@ function getNodePath(node: SceneNode) {
   return parts.join('/');
 }
 
+function waitForNextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
 export class CustomCommand<T> extends Command<T> {
   private readonly _execute: () => T | Promise<T>;
   private readonly _undo: () => void | Promise<void>;
@@ -285,8 +295,19 @@ export class NodeDeleteCommand extends Command {
   }
   async execute(): Promise<void> {
     const node = findNodeByPath(this._scene.rootNode, this._nodeId);
-    this._archive = await getEngine().resourceManager.serializeObject(node, null, null);
+    if (this._archive) {
+      node.remove();
+      return;
+    }
+    const parent = node.parent;
     node.remove();
+    try {
+      await waitForNextFrame();
+      this._archive = await getEngine().resourceManager.serializeObject(node, null, null);
+    } catch (err) {
+      node.parent = parent;
+      throw err;
+    }
   }
   async undo() {
     if (this._archive) {

--- a/utility/editor/src/commands/scenecommands.ts
+++ b/utility/editor/src/commands/scenecommands.ts
@@ -4,7 +4,7 @@ import { ParticleSystem } from '@zephyr3d/scene';
 import { Mesh } from '@zephyr3d/scene';
 import { Command } from '../core/command';
 import type { Nullable, RequireOptionals } from '@zephyr3d/base';
-import { ASSERT, Matrix4x4, Quaternion, Vector3 } from '@zephyr3d/base';
+import { ASSERT, DRef, Matrix4x4, Quaternion, Vector3 } from '@zephyr3d/base';
 import type { TRS } from '../types';
 
 export type CommandExecuteResult<T> = T extends AddAssetCommand ? SceneNode : void;
@@ -70,31 +70,44 @@ export class AddPrefabCommand extends Command<Nullable<SceneNode>> {
   private readonly _prefab: string;
   private _nodeId: string;
   private readonly _position: Vector3;
-  constructor(scene: Scene, prefab: string, position: Vector3) {
+  private _previewNodeRef: Nullable<DRef<SceneNode>>;
+  constructor(scene: Scene, prefab: string, position: Vector3, previewNode?: Nullable<SceneNode>) {
     super('Add Prefab');
     this._scene = scene;
     this._nodeId = '';
     this._prefab = prefab;
     this._position = new Vector3(position);
+    this._previewNodeRef = previewNode ? new DRef(previewNode) : null;
   }
   async execute() {
-    let prefab: Nullable<SceneNode> = null;
-    try {
-      prefab = await getEngine().resourceManager.instantiatePrefab(this._scene.rootNode, this._prefab);
-    } catch (err) {
-      console.error(`Load prefab failed: ${this._prefab}: ${err}`);
+    let prefab: Nullable<SceneNode> = this._previewNodeRef?.get() ?? null;
+    if (!prefab) {
+      try {
+        prefab = await getEngine().resourceManager.instantiatePrefab(this._scene.rootNode, this._prefab);
+      } catch (err) {
+        console.error(`Load prefab failed: ${this._prefab}: ${err}`);
+      }
     }
     if (prefab) {
+      prefab.parent = this._scene.rootNode;
       prefab.position.set(this._position);
+      prefab.iterate((node) => {
+        node.gpuPickable = true;
+        return false;
+      });
       if (this._nodeId) {
         // Restore persistent id if redo
         prefab.persistentId = this._nodeId.split('/').at(-1)!;
       } else {
         this._nodeId = getNodePath(prefab);
       }
+      this._previewNodeRef?.dispose();
+      this._previewNodeRef = null;
       return prefab;
     } else {
       this._nodeId = '';
+      this._previewNodeRef?.dispose();
+      this._previewNodeRef = null;
       return null;
     }
   }
@@ -111,32 +124,45 @@ export class AddAssetCommand extends Command<Nullable<SceneNode>> {
   private readonly _asset: string;
   private _nodeId: string;
   private readonly _position: Vector3;
-  constructor(scene: Scene, asset: string, position: Vector3) {
+  private _previewNodeRef: Nullable<DRef<SceneNode>>;
+  constructor(scene: Scene, asset: string, position: Vector3, previewNode?: Nullable<SceneNode>) {
     super('Add asset');
     this._scene = scene;
     this._nodeId = '';
     this._asset = asset;
     this._position = new Vector3(position);
+    this._previewNodeRef = previewNode ? new DRef(previewNode) : null;
   }
   async execute() {
-    let asset: Nullable<SceneNode> = null;
-    try {
-      //const model = await importModel(this._asset);
-      //asset = await model.createSceneNode(ProjectService.resourceManager, this._scene, false);
-      asset = await getEngine().resourceManager.fetchModel(this._asset, this._scene);
-    } catch (err) {
-      console.error(`Load asset failed: ${this._asset}: ${err}`);
+    let asset: Nullable<SceneNode> = this._previewNodeRef?.get() ?? null;
+    if (!asset) {
+      try {
+        //const model = await importModel(this._asset);
+        //asset = await model.createSceneNode(ProjectService.resourceManager, this._scene, false);
+        asset = await getEngine().resourceManager.fetchModel(this._asset, this._scene);
+      } catch (err) {
+        console.error(`Load asset failed: ${this._asset}: ${err}`);
+      }
     }
     if (asset) {
+      asset.parent = this._scene.rootNode;
       asset.position.set(this._position);
+      asset.iterate((node) => {
+        node.gpuPickable = true;
+        return false;
+      });
       if (this._nodeId) {
         asset.persistentId = this._nodeId.split('/').at(-1)!;
       } else {
         this._nodeId = getNodePath(asset);
       }
+      this._previewNodeRef?.dispose();
+      this._previewNodeRef = null;
       return asset;
     } else {
       this._nodeId = '';
+      this._previewNodeRef?.dispose();
+      this._previewNodeRef = null;
       return null;
     }
   }

--- a/utility/editor/src/commands/scenecommands.ts
+++ b/utility/editor/src/commands/scenecommands.ts
@@ -6,6 +6,12 @@ import { Command } from '../core/command';
 import type { Nullable, RequireOptionals } from '@zephyr3d/base';
 import { ASSERT, DRef, Matrix4x4, Quaternion, Vector3 } from '@zephyr3d/base';
 import type { TRS } from '../types';
+import {
+  ensureNodeDefaultName,
+  getDefaultNodeNameFromAssetPath,
+  getDefaultNodeNameFromCtor,
+  getDefaultShapeNodeName
+} from '../helpers/defaultnodename';
 
 export type CommandExecuteResult<T> = T extends AddAssetCommand ? SceneNode : void;
 
@@ -91,6 +97,7 @@ export class AddPrefabCommand extends Command<Nullable<SceneNode>> {
     if (prefab) {
       prefab.parent = this._scene.rootNode;
       prefab.position.set(this._position);
+      ensureNodeDefaultName(prefab, getDefaultNodeNameFromAssetPath(this._prefab));
       prefab.iterate((node) => {
         node.gpuPickable = true;
         return false;
@@ -147,6 +154,7 @@ export class AddAssetCommand extends Command<Nullable<SceneNode>> {
     if (asset) {
       asset.parent = this._scene.rootNode;
       asset.position.set(this._position);
+      ensureNodeDefaultName(asset, getDefaultNodeNameFromAssetPath(this._asset));
       asset.iterate((node) => {
         node.gpuPickable = true;
         return false;
@@ -179,13 +187,15 @@ export class AddChildCommand<T extends SceneNode = SceneNode> extends Command<Nu
   private readonly _scene: Scene;
   private _nodeId: string;
   private readonly _ctor: { new (scene: Scene): T };
-  constructor(parentNode: SceneNode, ctor: { new (scene: Scene): T }, position?: Vector3) {
+  private readonly _name: string;
+  constructor(parentNode: SceneNode, ctor: { new (scene: Scene): T }, position?: Vector3, name?: string) {
     super('Add child node');
     this._scene = parentNode.scene!;
     this._parentId = getNodePath(parentNode);
     this._nodeId = '';
     this._ctor = ctor;
     this._position = position ?? null;
+    this._name = name?.trim() ?? '';
   }
   async execute() {
     const parent = findNodeByPath(this._scene.rootNode, this._parentId);
@@ -198,6 +208,11 @@ export class AddChildCommand<T extends SceneNode = SceneNode> extends Command<Nu
     node.parent = parent;
     if (this._position) {
       node.position.set(this._position);
+    }
+    if (this._name) {
+      node.name = this._name;
+    } else {
+      ensureNodeDefaultName(node, getDefaultNodeNameFromCtor(this._ctor));
     }
     if (this._nodeId) {
       node.persistentId = this._nodeId.split('/').at(-1)!;
@@ -284,6 +299,8 @@ export class AddShapeCommand extends Command<Mesh> {
     mesh.parent = parent;
     if (this._name) {
       mesh.name = this._name;
+    } else {
+      ensureNodeDefaultName(mesh, getDefaultShapeNodeName(this._shapeCls));
     }
     mesh.position.set(this._position);
     if (this._scale) {

--- a/utility/editor/src/components/scenehierarchy.ts
+++ b/utility/editor/src/components/scenehierarchy.ts
@@ -143,6 +143,12 @@ export class SceneHierarchy extends TreeView<
   protected onGetContextMenuId(node: SceneNode): string {
     return `context_${node.runtimeId}`;
   }
+  protected onGetContentContextMenuId(): string {
+    return 'scene_hierarchy_content_context';
+  }
+  protected onDrawContentContextMenu(_menuId: string) {
+    this.drawCreateNodeActions(this._scene.rootNode);
+  }
   protected onDrawContextMenu(node: SceneNode, _menuId: string) {
     const pluginCtx = this._getPluginContext(node);
     const pluginItems =
@@ -162,13 +168,7 @@ export class SceneHierarchy extends TreeView<
       }
       ImGui.Separator();
     }
-    if (ImGui.MenuItem('Create Batch Group')) {
-      this.dispatchEvent('request_add_child', node, BatchGroup);
-    }
-    ImGui.Separator();
-    if (ImGui.MenuItem('Create Empty Node')) {
-      this.dispatchEvent('request_add_child', node, SceneNode);
-    }
+    this.drawCreateNodeActions(node);
     ImGui.Separator();
     if (ImGui.MenuItem('Create Prefab...')) {
       this.dispatchEvent('request_save_prefab', node);
@@ -210,6 +210,15 @@ export class SceneHierarchy extends TreeView<
       if (ImGui.MenuItem('Make Active')) {
         this.dispatchEvent('set_main_camera', node);
       }
+    }
+  }
+  private drawCreateNodeActions(target: SceneNode) {
+    if (ImGui.MenuItem('Create Batch Group')) {
+      this.dispatchEvent('request_add_child', target, BatchGroup);
+    }
+    ImGui.Separator();
+    if (ImGui.MenuItem('Create Empty Node')) {
+      this.dispatchEvent('request_add_child', target, SceneNode);
     }
   }
   protected onDragDrop(node: SceneNode, _type: string, payload: unknown) {

--- a/utility/editor/src/components/treeview.ts
+++ b/utility/editor/src/components/treeview.ts
@@ -43,6 +43,7 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
   private _pendingClickRowIndex: number;
   private _pendingClickCtrl: boolean;
   private _pendingClickShift: boolean;
+  private _rowHoveredThisFrame: boolean;
 
   constructor(id: string, data: TreeViewData<T>, multiSelect = false) {
     super();
@@ -61,6 +62,7 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
     this._pendingClickRowIndex = -1;
     this._pendingClickCtrl = false;
     this._pendingClickShift = false;
+    this._rowHoveredThisFrame = false;
     this._clipper = new ImGui.ListClipper();
   }
 
@@ -98,6 +100,7 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
     const flags = this._draggingItem ? ImGui.WindowFlags.NoScrollbar : 0;
     ImGui.BeginChild(this._id, ImGui.GetContentRegionAvail(), false, flags);
     ImGui.PushID(this._id);
+    this._rowHoveredThisFrame = false;
     if (!ImGui.GetIO().MouseDown[0]) {
       this._draggingItem = false;
     }
@@ -114,6 +117,7 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
     this.flushPendingClick();
     this.handleAutoScrollWhileDragging();
     this.ensureSelectionVisible();
+    this.handleContentContextMenu();
     ImGui.PopID();
     ImGui.EndChild();
   }
@@ -190,6 +194,9 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
     }
     if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(ImGui.MouseButton.Left)) {
       this.onNodeDblClicked(node);
+    }
+    if (ImGui.IsItemHovered(ImGui.HoveredFlags.AllowWhenBlockedByPopup)) {
+      this._rowHoveredThisFrame = true;
     }
 
     const menuId = this.onGetContextMenuId(node);
@@ -300,11 +307,32 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
   protected onGetNodeTextColor(_node: T): Nullable<ImGui.ImVec4> {
     return null;
   }
+  protected onGetContentContextMenuId(): string {
+    return '';
+  }
   protected onGetContextMenuId(_node: T): string {
     return '';
   }
+  protected onDrawContentContextMenu(_menuId: string) {}
   protected onDrawContextMenu(_node: T, _menuId: string) {}
   protected onDragDrop(_node: T, _type: string, _payload: unknown) {}
+  private handleContentContextMenu() {
+    const menuId = this.onGetContentContextMenuId();
+    if (!menuId) {
+      return;
+    }
+    if (
+      ImGui.IsWindowHovered(ImGui.HoveredFlags.AllowWhenBlockedByPopup) &&
+      ImGui.IsMouseClicked(ImGui.MouseButton.Right) &&
+      !this._rowHoveredThisFrame
+    ) {
+      ImGui.OpenPopup(menuId);
+    }
+    if (ImGui.BeginPopup(menuId)) {
+      this.onDrawContentContextMenu(menuId);
+      ImGui.EndPopup();
+    }
+  }
   private expandAncestors(node: T) {
     let cur = node;
     for (;;) {

--- a/utility/editor/src/components/treeview.ts
+++ b/utility/editor/src/components/treeview.ts
@@ -87,6 +87,9 @@ export class TreeView<P extends EventMap, T = unknown> extends Observable<P> {
     this._openState.clear();
     this._visibleDirty = true;
   }
+  refreshStructure() {
+    this._visibleDirty = true;
+  }
   render(forceUpdate: boolean) {
     if (this._visibleDirty || forceUpdate) {
       this.rebuildVisible();

--- a/utility/editor/src/components/vfsrenderer.ts
+++ b/utility/editor/src/components/vfsrenderer.ts
@@ -1245,6 +1245,8 @@ export class VFSRenderer extends makeObservable(Disposable)<{
     }
 
     const items = Array.from(this.selectedItems);
+    const deletedPaths = items.map((item) => ('subDir' in item ? item.path : item.meta.path));
+    eventBus.dispatchEvent('assets_deleting', deletedPaths);
     const deletePromises = items.map((item) => {
       const isDir = 'subDir' in item;
       if (isDir) {
@@ -1256,7 +1258,6 @@ export class VFSRenderer extends makeObservable(Disposable)<{
 
     Promise.all(deletePromises)
       .then(() => {
-        const deletedPaths = items.map((item) => ('subDir' in item ? item.path : item.meta.path));
         this.removePathsFromFileSystem(deletedPaths);
         this._contentView.deselectAll();
         this.refreshFileView();

--- a/utility/editor/src/components/vfsrenderer.ts
+++ b/utility/editor/src/components/vfsrenderer.ts
@@ -562,6 +562,7 @@ export class VFSRenderer extends makeObservable(Disposable)<{
   private _reloadingFileSystem = false;
   private _vfsBatchDepth = 0;
   private _vfsBatchReloadPending = false;
+  private _selectedDirPath: string | null = null;
   private readonly _options: VFSRendererOptions = null;
 
   constructor(vfs: VFS, fileFilter: string[] = [], treePanelWidth = 200, options?: VFSRendererOptions) {
@@ -1537,16 +1538,20 @@ export class VFSRenderer extends makeObservable(Disposable)<{
   }
 
   async loadFileSystem() {
+    const previousSelectedDirPath =
+      this._selectedDirPath ??
+      (this.selectedDir ? this._vfs.normalizePath(this.selectedDir.path) : this._options.rootDir);
     const rootDir = await this.loadDirectoryInfo(this._options.rootDir, 1);
     this._filesystem = rootDir;
     this._forceNavRefresh = true;
 
-    if (this.selectedDir) {
-      const newSelectedDir = this.findDirectoryByPath(this._filesystem, this.selectedDir.path);
-      this._nav.selectNode(newSelectedDir ?? null);
-    } else {
-      this._nav.selectNode(this._filesystem);
+    let selectedDir: DirectoryInfo | null = this._filesystem;
+    if (previousSelectedDirPath) {
+      await this.ensureDirectoryChainLoaded(previousSelectedDirPath);
+      selectedDir = this.findDirectoryByPath(this._filesystem, previousSelectedDirPath) ?? this._filesystem;
     }
+    this._nav.selectNode(selectedDir);
+    this._selectedDirPath = this._vfs.normalizePath(selectedDir?.path ?? this._options.rootDir);
     if (this._pendingRevealAssetPath) {
       const path = this._pendingRevealAssetPath;
       this._pendingRevealAssetPath = null;
@@ -1893,6 +1898,7 @@ export class VFSRenderer extends makeObservable(Disposable)<{
   }
 
   emitSelectedChanged() {
+    this._selectedDirPath = this.selectedDir ? this._vfs.normalizePath(this.selectedDir.path) : null;
     this.dispatchEvent('selection_changed', this.selectedDir ?? null, this.selectedFiles, [
       ...this.selectedItems
     ]);

--- a/utility/editor/src/core/command.ts
+++ b/utility/editor/src/core/command.ts
@@ -18,15 +18,21 @@ export class CommandManager {
   private _undoStack: Command<any>[];
   private _current: number;
   private _pending: Promise<void>;
+  private _activeTaskCount: number;
   constructor() {
     this._undoStack = [];
     this._current = 0;
     this._pending = Promise.resolve();
+    this._activeTaskCount = 0;
   }
   clear() {
     this._undoStack = [];
     this._current = 0;
     this._pending = Promise.resolve();
+    this._activeTaskCount = 0;
+  }
+  get busy() {
+    return this._activeTaskCount > 0;
   }
   async execute<T>(command: Command<T>): Promise<T> {
     return this.enqueue(async () => {
@@ -62,7 +68,10 @@ export class CommandManager {
   private enqueue<T>(task: () => Promise<T>): Promise<T> {
     let run: Promise<T> | null = null;
     const next = this._pending.then(() => {
-      run = task();
+      this._activeTaskCount++;
+      run = task().finally(() => {
+        this._activeTaskCount = Math.max(0, this._activeTaskCount - 1);
+      });
       return run.then(
         () => undefined,
         () => undefined

--- a/utility/editor/src/core/command.ts
+++ b/utility/editor/src/core/command.ts
@@ -17,27 +17,25 @@ export abstract class Command<T = void> {
 export class CommandManager {
   private _undoStack: Command<any>[];
   private _current: number;
-  private _executing: boolean;
+  private _pending: Promise<void>;
   constructor() {
     this._undoStack = [];
     this._current = 0;
-    this._executing = false;
+    this._pending = Promise.resolve();
   }
   clear() {
     this._undoStack = [];
     this._current = 0;
+    this._pending = Promise.resolve();
   }
   async execute<T>(command: Command<T>): Promise<T> {
-    if (!this._executing) {
-      this._executing = true;
+    return this.enqueue(async () => {
       const result = await command.execute();
       this._undoStack.splice(this._current);
       this._undoStack.push(command);
       this._current++;
-      this._executing = false;
       return result;
-    }
-    return null;
+    });
   }
   getUndoCommand(): Command {
     return this._current > 0 ? this._undoStack[this._current - 1] : null;
@@ -46,18 +44,32 @@ export class CommandManager {
     return this._current < this._undoStack.length ? this._undoStack[this._current] : null;
   }
   async undo() {
-    if (!this._executing && this._current > 0) {
-      this._executing = true;
+    return this.enqueue(async () => {
+      if (this._current <= 0) {
+        return;
+      }
       await this._undoStack[--this._current].undo();
-      this._executing = false;
-    }
+    });
   }
   async redo() {
-    if (!this._executing && this._current < this._undoStack.length) {
-      this._executing = true;
+    return this.enqueue(async () => {
+      if (this._current >= this._undoStack.length) {
+        return;
+      }
       await this._undoStack[this._current++].execute();
-      this._executing = false;
-    }
+    });
+  }
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    let run: Promise<T> | null = null;
+    const next = this._pending.then(() => {
+      run = task();
+      return run.then(
+        () => undefined,
+        () => undefined
+      );
+    });
+    this._pending = next;
+    return next.then(() => run!);
   }
 }
 

--- a/utility/editor/src/core/editor.ts
+++ b/utility/editor/src/core/editor.ts
@@ -5,7 +5,7 @@ import { DialogRenderer } from '../components/modal';
 import { ModuleManager } from './module';
 import { SceneController } from '../controllers/scenecontroller';
 import { FontGlyph } from './fontglyph';
-import { AssetManager, ResourceManager, getEngine } from '@zephyr3d/scene';
+import { AssetManager, ResourceManager, getDevice, getEngine } from '@zephyr3d/scene';
 import type { Texture2D } from '@zephyr3d/device';
 import {
   analyzeGPUObjectGrowth,
@@ -38,6 +38,7 @@ import {
   type SystemPluginRecord
 } from './services/systemplugin';
 import { isDesktopApp } from './services/desktop';
+import type { SceneView } from '../views/sceneview';
 
 type TreeData = { files: { name: string; size: number }[]; subDirs: { [name: string]: TreeData } };
 
@@ -227,6 +228,15 @@ export class Editor {
   }
   update(dt: number) {
     eventBus.dispatchEvent('update', dt);
+  }
+  private updateBusyCursor() {
+    const sceneController = this._moduleManager.currentModule?.controller as SceneController;
+    const sceneView = sceneController?.view as SceneView;
+    const canvas = getDevice()?.canvas;
+    if (!canvas) {
+      return;
+    }
+    canvas.style.cursor = sceneView?.busy ? 'wait' : '';
   }
   getBrushes() {
     return this._assetImages.brushes;
@@ -461,6 +471,7 @@ export class Editor {
     }
     DialogRenderer.render();
     imGuiEndFrame();
+    this.updateBusyCursor();
   }
   renderWelcomePage() {
     const io = ImGui.GetIO();

--- a/utility/editor/src/core/eventbus.ts
+++ b/utility/editor/src/core/eventbus.ts
@@ -26,6 +26,7 @@ type EventBusEventMap = {
   edit_material: [label: string, outputName: string, type: GenericConstructor<MeshMaterial>, path: string];
   edit_material_function: [path: string];
   reveal_asset: [path: string];
+  assets_deleting: [paths: string[]];
 };
 
 export class EventBus extends Observable<EventBusEventMap> {}

--- a/utility/editor/src/helpers/defaultnodename.ts
+++ b/utility/editor/src/helpers/defaultnodename.ts
@@ -1,0 +1,44 @@
+import { PathUtils } from '@zephyr3d/base';
+import type { Nullable } from '@zephyr3d/base';
+import type { Scene, SceneNode } from '@zephyr3d/scene';
+
+export type SceneNodeCtor<T extends SceneNode = SceneNode> = { new (scene: Scene): T };
+
+const ctorNameOverrides: Record<string, string> = {
+  SceneNode: 'Empty Node',
+  BatchGroup: 'Batch Group',
+  ClipmapTerrain: 'Terrain',
+  MSDFText: 'MSDFText'
+};
+
+function toTitleCase(value: string) {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .map((word) => (word ? `${word[0].toUpperCase()}${word.slice(1)}` : ''))
+    .join(' ');
+}
+
+export function getDefaultNodeNameFromAssetPath(path: string) {
+  const ext = PathUtils.extname(path);
+  return PathUtils.basename(path, ext);
+}
+
+export function getDefaultShapeNodeName(path: string) {
+  const ext = PathUtils.extname(path);
+  return toTitleCase(PathUtils.basename(path, ext));
+}
+
+export function getDefaultNodeNameFromCtor(ctor: SceneNodeCtor) {
+  return ctorNameOverrides[ctor.name] ?? toTitleCase(ctor.name || 'Node');
+}
+
+export function ensureNodeDefaultName(node: Nullable<SceneNode>, name: string) {
+  if (!node || node.name?.trim() || !name?.trim()) {
+    return;
+  }
+  node.name = name;
+}

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -1311,19 +1311,17 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
             switch (this._typeToBePlaced) {
               case 'asset':
                 this._cmdManager
-                  .execute(new AddAssetCommand(this.controller.model.scene, this._assetToBeAdded!, pos))
+                  .execute(new AddAssetCommand(this.controller.model.scene, this._assetToBeAdded!, pos, placeNode))
                   .then((node) => {
                     this._sceneHierarchy!.selectNode(node);
-                    placeNode.parent = null;
                     eventBus.dispatchEvent('scene_changed');
                   });
                 break;
               case 'prefab':
                 this._cmdManager
-                  .execute(new AddPrefabCommand(this.controller.model.scene, this._assetToBeAdded!, pos))
+                  .execute(new AddPrefabCommand(this.controller.model.scene, this._assetToBeAdded!, pos, placeNode))
                   .then((node) => {
                     this._sceneHierarchy!.selectNode(node);
-                    placeNode.parent = null;
                     eventBus.dispatchEvent('scene_changed');
                   });
                 break;
@@ -2476,8 +2474,8 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       this._nodeToBePlaced.dispose();
       const command =
         this._typeToBePlaced === 'asset'
-          ? new AddAssetCommand(this.controller.model.scene, this._assetToBeAdded!, pos)
-          : new AddPrefabCommand(this.controller.model.scene, this._assetToBeAdded!, pos);
+          ? new AddAssetCommand(this.controller.model.scene, this._assetToBeAdded!, pos, placeNode)
+          : new AddPrefabCommand(this.controller.model.scene, this._assetToBeAdded!, pos, placeNode);
       this._cmdManager.execute(command).then((node) => {
         this._sceneHierarchy!.selectNode(node);
         eventBus.dispatchEvent('scene_changed');

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -1540,6 +1540,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     eventBus.on('workspace_drag_end', this.handleWorkspaceDragEnd, this);
     eventBus.on('workspace_dragging', this.handleWorkspaceDragging, this);
     eventBus.on('workspace_drag_drop', this.handleWorkspaceDragDrop, this);
+    eventBus.on('assets_deleting', this.handleAssetsDeleting, this);
     eventBus.on('edit_material', this.editMaterial, this);
     eventBus.on('edit_material_function', this.editMaterialFunction, this);
     this.reset();
@@ -1571,6 +1572,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     eventBus.off('workspace_drag_end', this.handleWorkspaceDragEnd, this);
     eventBus.off('workspace_dragging', this.handleWorkspaceDragging, this);
     eventBus.off('workspace_drag_drop', this.handleWorkspaceDragDrop, this);
+    eventBus.off('assets_deleting', this.handleAssetsDeleting, this);
     eventBus.off('edit_material', this.editMaterial, this);
     eventBus.off('edit_material_function', this.editMaterialFunction, this);
     this.endEditAll();
@@ -2625,6 +2627,63 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
   private handleNodeDeselected(_node: SceneNode) {}
   private handleAssetSelectionChanged() {
     this._lastDuplicateTarget = 'asset';
+  }
+  private handleAssetsDeleting(paths: string[]) {
+    const scene = this.controller.model.scene;
+    if (!scene || !paths?.length) {
+      return;
+    }
+    const normalizedPaths = paths.map((path) => ProjectService.VFS.normalizePath(path)).filter(Boolean);
+    if (normalizedPaths.length === 0) {
+      return;
+    }
+    const matchedNodes: SceneNode[] = [];
+    scene.rootNode.iterateBottomToTop((node) => {
+      if (node === scene.rootNode) {
+        return false;
+      }
+      const prefabNode = node.getPrefabNode();
+      const prefabPath = prefabNode?.prefabId?.startsWith('/')
+        ? ProjectService.VFS.normalizePath(prefabNode.prefabId)
+        : '';
+      const assetId = getEngine().resourceManager.getAssetId(node);
+      const assetPath =
+        typeof assetId === 'string' && assetId.startsWith('/') ? ProjectService.VFS.normalizePath(assetId) : '';
+      const matched = normalizedPaths.some(
+        (path) =>
+          prefabPath === path ||
+          assetPath === path ||
+          (ProjectService.VFS.isParentOf(path, prefabPath) && prefabPath !== path) ||
+          (ProjectService.VFS.isParentOf(path, assetPath) && assetPath !== path)
+      );
+      if (matched) {
+        matchedNodes.push(node);
+      }
+      return false;
+    });
+    const removedNodes = matchedNodes.filter(
+      (node) => !matchedNodes.some((other) => other !== node && other.isParentOf(node))
+    );
+    if (removedNodes.length > 0) {
+      for (const node of removedNodes) {
+        node.remove();
+      }
+      this._sceneHierarchy?.refreshStructure();
+      if (
+        this._propGrid.object instanceof SceneNode &&
+        removedNodes.some((node) => node.isParentOf(this._propGrid.object))
+      ) {
+        this._propGrid.object = scene;
+      }
+      if (removedNodes.some((node) => node.isParentOf(this._postGizmoRenderer?.node))) {
+        this._postGizmoRenderer!.node = null;
+      }
+      const selectedNodes = this.getSelectedSceneNodes();
+      if (removedNodes.some((node) => selectedNodes.some((selected) => node.isParentOf(selected)))) {
+        this._sceneHierarchy?.selectNode(null);
+      }
+      eventBus.dispatchEvent('scene_changed');
+    }
   }
   private handleDuplicateShortcut(): boolean {
     const selectedNodes = this.getSelectedSceneNodes();

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -163,6 +163,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
   private _springBoneColliderGizmo: ShapeGizmo;
   private _springBone: JointDynamicsModifier;
   private _propGridScrollTopFrames: number;
+  private _assetPlacementLoadingCount: number;
   constructor(controller: SceneController) {
     super(controller);
     this._cmdManager = new CommandManager();
@@ -189,6 +190,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     this._springBoneColliderGizmo = null;
     this._springBone = null;
     this._propGridScrollTopFrames = 0;
+    this._assetPlacementLoadingCount = 0;
     this._currentEditTool = new DRef();
     this._cameraAnimationEyeFrom = new Vector3();
     this._cameraAnimationTargetFrom = new Vector3();
@@ -268,6 +270,9 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
   }
   get cmdManager() {
     return this._cmdManager;
+  }
+  get busy() {
+    return this._cmdManager.busy || this._assetPlacementLoadingCount > 0;
   }
   get editToolContext() {
     return this._editToolContext;
@@ -2711,6 +2716,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       this._nodeToBePlaced.dispose();
       this._typeToBePlaced = 'none';
     }
+    this._assetPlacementLoadingCount++;
     getEngine()
       .resourceManager.instantiatePrefab(this.controller.model.scene.rootNode, prefab)
       .then((node) => {
@@ -2722,6 +2728,9 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
         this._assetToBeAdded = prefab;
         this._typeToBePlaced = 'prefab';
         this._ctorToBePlaced = null;
+      })
+      .finally(() => {
+        this._assetPlacementLoadingCount = Math.max(0, this._assetPlacementLoadingCount - 1);
       });
   }
   private handleAddAsset(asset: string) {
@@ -2731,6 +2740,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       this._nodeToBePlaced.dispose();
       this._typeToBePlaced = 'none';
     }
+    this._assetPlacementLoadingCount++;
     getEngine()
       .resourceManager.fetchModel(asset, this.controller.model.scene)
       .then((node) => {
@@ -2745,6 +2755,9 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       })
       .catch((err) => {
         Dialog.messageBox('Error', `${err}`);
+      })
+      .finally(() => {
+        this._assetPlacementLoadingCount = Math.max(0, this._assetPlacementLoadingCount - 1);
       });
   }
   private handleAddChild(parent: SceneNode, ctor: { new (scene: Scene): SceneNode }) {

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -2787,6 +2787,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     });
   }
   private handleNodeRemoved(node: SceneNode) {
+    this._sceneHierarchy?.refreshStructure();
     if (node.isParentOf(this._postGizmoRenderer!.node!)) {
       this._postGizmoRenderer!.node = null;
     }
@@ -2796,6 +2797,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     }
   }
   private handleNodeAttached(node: SceneNode) {
+    this._sceneHierarchy?.refreshStructure();
     queueMicrotask(() => {
       this.syncNodeProxyTree(node);
     });

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -2175,6 +2175,16 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
   private getTopLevelSelection(nodes: SceneNode[]) {
     return nodes.filter((node) => !nodes.some((other) => other !== node && other.isParentOf(node)));
   }
+  private getHierarchyDragSelection(src: SceneNode, dst: SceneNode) {
+    const selectedNodes = this.getTopLevelSelection(this.getSelectedSceneNodes()).filter(
+      (node) => node && node !== this.controller.model.scene.rootNode
+    );
+    const dragNodes = selectedNodes.includes(src) ? selectedNodes : [src];
+    if (dragNodes.some((node) => node === dst || node.isParentOf(dst))) {
+      return [];
+    }
+    return dragNodes.filter((node) => node.parent !== dst);
+  }
   private ensureMultiTransformPivot() {
     if (!this._multiTransformPivot) {
       this._multiTransformPivot = new SceneNode(this.controller.model.scene);
@@ -2634,10 +2644,20 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     return false;
   }
   private handleNodeDragDrop(src: SceneNode, dst: SceneNode) {
-    if (src.parent !== dst && !src.isParentOf(dst)) {
-      this._cmdManager.execute(new NodeReparentCommand(src, dst)).then(() => {
-        eventBus.dispatchEvent('scene_changed');
-      });
+    const dragNodes = this.getHierarchyDragSelection(src, dst);
+    if (dragNodes.length === 0) {
+      return;
+    }
+    const commands = dragNodes.map((node) => new NodeReparentCommand(node, dst));
+    const activeNode = dragNodes.includes(src) ? src : dragNodes[dragNodes.length - 1];
+    const onDone = () => {
+      this._sceneHierarchy?.selectNodes(dragNodes, activeNode);
+      eventBus.dispatchEvent('scene_changed');
+    };
+    if (commands.length === 1) {
+      this._cmdManager.execute(commands[0]).then(onDone);
+    } else {
+      this._cmdManager.execute(new CompositeCommand('Reparent objects', commands)).then(onDone);
     }
   }
   private handleNodePickerDrop(payload: SceneHierarchyNodePickerPayload, dst: SceneNode) {

--- a/utility/editor/src/views/sceneview.ts
+++ b/utility/editor/src/views/sceneview.ts
@@ -69,6 +69,12 @@ import { NodeProxy } from '../helpers/proxy';
 import { clearScriptPropertyAccessorCache } from '../helpers/scriptprops';
 import { getMorphTargetGroupPropertyAccessors } from '../helpers/morphtargetprops';
 import { shapePrimitivePaths, type ShapePrimitiveType } from '../helpers/shapeprimitives';
+import {
+  ensureNodeDefaultName,
+  getDefaultNodeNameFromAssetPath,
+  getDefaultNodeNameFromCtor,
+  getDefaultShapeNodeName
+} from '../helpers/defaultnodename';
 import type { EditTool, EditToolContext } from './edittools/edittool';
 import { createEditTool, isObjectEditable } from './edittools/edittool';
 import { calcHierarchyBoundingBoxWorld } from '../helpers/misc';
@@ -2706,6 +2712,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     );
     const mesh = new Mesh(this.controller.model.scene, shape!, material!);
     mesh.gpuPickable = false;
+    ensureNodeDefaultName(mesh, getDefaultShapeNodeName(shapeCls));
     this._nodeToBePlaced.set(mesh);
     this._shapeToBeAdded = {
       cls: shapeCls
@@ -2723,6 +2730,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
     const node = new ctor(this.controller.model.scene);
     node.parent = null;
     node.gpuPickable = false;
+    ensureNodeDefaultName(node, getDefaultNodeNameFromCtor(ctor));
     this._proxy!.createProxy(node);
     this._nodeToBePlaced.set(node);
     this._typeToBePlaced = 'node';
@@ -2741,6 +2749,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       .resourceManager.instantiatePrefab(this.controller.model.scene.rootNode, prefab)
       .then((node) => {
         node!.parent = null;
+        ensureNodeDefaultName(node, getDefaultNodeNameFromAssetPath(prefab));
         node!.iterate((node) => {
           node.gpuPickable = false;
         });
@@ -2765,6 +2774,7 @@ export class SceneView extends BaseView<SceneModel, SceneController> {
       .resourceManager.fetchModel(asset, this.controller.model.scene)
       .then((node) => {
         node.parent = null;
+        ensureNodeDefaultName(node, getDefaultNodeNameFromAssetPath(asset));
         node.iterate((node) => {
           node.gpuPickable = false;
         });


### PR DESCRIPTION
- 修复资产浏览器重载后回到根目录问题
- 优化场景节点删除的层级同步反馈
- 优化编辑器命令执行队列
- 优化场景拖入模型的落地性能
- 补充编辑器忙碌光标反馈
- 优化场景节点树交互体验
- 补充场景节点默认命名
- 增强删除资产时的场景引用安全

## 变更目标

- 提升场景编辑和资产管理过程中的一致性、反馈性和安全性
- 减少目录刷新、删除资产、拖入模型等操作带来的误导或卡顿感
- 改善节点树和场景工作流的整体体验

## 如何测试

- 验证资产浏览器刷新后是否还能停留在原目录
- 验证删除节点、删除资产、拖入模型、默认命名、忙碌光标等交互
- 验证删除被引用资产后场景是否能安全处理相关引用