### PR TITLE
fix(scene): 修正 humanoid 辅助节点误匹配

### DIFF
--- a/libs/scene/src/animation/skeleton.ts
+++ b/libs/scene/src/animation/skeleton.ts
@@ -131,6 +131,8 @@ type HumanoidJointPattern = {
 
 type HumanoidJointProfile<T extends string> = Record<T, HumanoidJointPattern[]>;
 
+const humanoidHelperJointTokens = new Set(['end', 'nub', 'socket']);
+
 type HumanoidJointNodeInfo<T extends { name: string; children: T[] }> = {
   node: T;
   depth: number;
@@ -887,6 +889,7 @@ export class SkinBinding extends Disposable {
   }
   private static normalizeHumanoidJointName(name: string) {
     return name
+      .slice(name.lastIndexOf(':') + 1)
       .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
       .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
       .replace(/([a-zA-Z])(\d+)/g, '$1 $2')
@@ -930,7 +933,7 @@ export class SkinBinding extends Disposable {
         return false;
       }
       const tokens = normalizedName.split(' ').filter(Boolean);
-      if (!tokens.length) {
+      if (!tokens.length || tokens.some((token) => humanoidHelperJointTokens.has(token))) {
         return false;
       }
       nodes.push({

--- a/test/src/scene/skeleton_humanoid.test.ts
+++ b/test/src/scene/skeleton_humanoid.test.ts
@@ -416,7 +416,10 @@ function buildBipedBodyOnlySkeleton() {
   return root;
 }
 
-function buildMetaHumanBodySkeleton(prefix = '') {
+function buildMetaHumanBodySkeleton(
+  prefix = '',
+  options: { headName?: string; leftHandName?: string; includeDecoys?: boolean } = {}
+) {
   const root = new SceneNode(null);
   root.name = `${prefix}root`;
 
@@ -426,7 +429,13 @@ function buildMetaHumanBodySkeleton(prefix = '') {
     spine = appendNode(spine, `${prefix}spine_${String(i).padStart(2, '0')}`);
   }
   const neck = appendNode(spine, `${prefix}neck_01`);
-  appendNode(appendNode(neck, `${prefix}neck_02`), `${prefix}head`);
+  const head = appendNode(appendNode(neck, `${prefix}neck_02`), options.headName ?? `${prefix}head`);
+  if (options.includeDecoys) {
+    appendNode(head, 'HeadAux');
+    appendNode(head, 'HeadSocket');
+    appendNode(head, 'Head_End');
+    appendNode(head, 'HeadNub');
+  }
 
   for (const side of ['l', 'r'] as const) {
     const upperLeg = appendNode(hips, `${prefix}thigh_${side}`);
@@ -436,7 +445,16 @@ function buildMetaHumanBodySkeleton(prefix = '') {
     const shoulder = appendNode(spine, `${prefix}clavicle_${side}`);
     const upperArm = appendNode(shoulder, `${prefix}upperarm_${side}`);
     const lowerArm = appendNode(upperArm, `${prefix}lowerarm_${side}`);
-    appendNode(lowerArm, `${prefix}hand_${side}`);
+    const hand = appendNode(
+      lowerArm,
+      side === 'l' ? (options.leftHandName ?? `${prefix}hand_${side}`) : `${prefix}hand_${side}`
+    );
+    if (options.includeDecoys) {
+      const sideName = side === 'l' ? 'Left' : 'Right';
+      appendNode(hand, `${sideName}HandSocket`);
+      appendNode(hand, `${sideName}Hand_End`);
+      appendNode(hand, `${sideName}HandNub`);
+    }
   }
 
   return root;
@@ -590,14 +608,31 @@ describe('Skeleton.tryExtractHumanoidBones', () => {
 
   test('extracts MetaHuman body bones with optional namespace prefixes', () => {
     for (const prefix of ['', 'MHBody:']) {
-      const result = Skeleton.tryExtractHumanoidJoints(buildMetaHumanBodySkeleton(prefix));
+      const result = Skeleton.tryExtractHumanoidJoints(
+        buildMetaHumanBodySkeleton(prefix, { includeDecoys: true })
+      );
       expect(result).not.toBeNull();
       expect(result!.body[HumanoidBodyRig.Hips].name).toBe(`${prefix}pelvis`);
       expect(result!.body[HumanoidBodyRig.Spine].name).toBe(`${prefix}spine_01`);
       expect(result!.body[HumanoidBodyRig.UpperChest].name).toBe(`${prefix}spine_05`);
+      expect(result!.body[HumanoidBodyRig.Head].name).toBe(`${prefix}head`);
+      expect(result!.body[HumanoidBodyRig.LeftHand].name).toBe(`${prefix}hand_l`);
+      expect(result!.body[HumanoidBodyRig.RightHand].name).toBe(`${prefix}hand_r`);
       expect(result!.body[HumanoidBodyRig.LeftToes].name).toBe(`${prefix}ball_l`);
       expect(result!.body[HumanoidBodyRig.RightToes].name).toBe(`${prefix}ball_r`);
     }
+  });
+
+  test.each([
+    ['HeadSocket', { headName: 'HeadSocket' }],
+    ['Head_End', { headName: 'Head_End' }],
+    ['HeadNub', { headName: 'HeadNub' }],
+    ['LeftHandSocket', { leftHandName: 'LeftHandSocket' }],
+    ['LeftHand_End', { leftHandName: 'LeftHand_End' }],
+    ['LeftHandNub', { leftHandName: 'LeftHandNub' }]
+  ])('rejects helper-only humanoid joint candidate %s', (_name, options) => {
+    const result = Skeleton.tryExtractHumanoidJoints(buildMetaHumanBodySkeleton('MHBody:', options));
+    expect(result).toBeNull();
   });
 
   test('prefers the torso chain that is hierarchy-consistent with the limbs', () => {


### PR DESCRIPTION
- 骨骼名称规范化前剥离冒号命名空间，避免 MHBody、mixamorig 等前缀影响候选评分
- 全局排除 socket、end、nub 辅助节点，防止 HeadSocket 或末端节点替代真实人体骨
- 补充 MetaHuman 命名空间、头手干扰节点及仅有辅助候选时的回归测试